### PR TITLE
ci(workflows): add reusable GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,47 @@
+name: Build and Test (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      dotnet-version:
+        description: 'The .NET SDK version to use'
+        required: false
+        type: string
+        default: '10.0.x'
+      configuration:
+        description: 'Build configuration'
+        required: false
+        type: string
+        default: 'Release'
+      runs-on:
+        description: 'The runner to use'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      working-directory:
+        description: 'Working directory for operations'
+        required: false
+        type: string
+        default: '.'
+      enable-cache:
+        description: 'Enable dependency caching'
+        required: false
+        type: boolean
+        default: true
+      collect-coverage:
+        description: 'Collect test coverage'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    uses: ./.github/workflows/templates/jobs/build-and-test.yml
+    with:
+      dotnet-version: ${{ inputs.dotnet-version }}
+      configuration: ${{ inputs.configuration }}
+      runs-on: ${{ inputs.runs-on }}
+      working-directory: ${{ inputs.working-directory }}
+      enable-cache: ${{ inputs.enable-cache }}
+      collect-coverage: ${{ inputs.collect-coverage }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,11 +37,61 @@ on:
 jobs:
   build-and-test:
     name: Build and Test
-    uses: ./.github/workflows/templates/jobs/build-and-test.yml
-    with:
-      dotnet-version: ${{ inputs.dotnet-version }}
-      configuration: ${{ inputs.configuration }}
-      runs-on: ${{ inputs.runs-on }}
-      working-directory: ${{ inputs.working-directory }}
-      enable-cache: ${{ inputs.enable-cache }}
-      collect-coverage: ${{ inputs.collect-coverage }}
+    runs-on: ${{ inputs.runs-on }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup .NET
+        uses: ./.github/actions/dotnet/setup
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+      
+      - name: Setup NuGet cache
+        if: ${{ inputs.enable-cache }}
+        uses: ./.github/actions/nuget/setup-cache
+        with:
+          working-directory: ${{ inputs.working-directory }}
+      
+      - name: Restore dependencies
+        uses: ./.github/actions/dotnet/restore
+        with:
+          working-directory: ${{ inputs.working-directory }}
+      
+      - name: Build solution
+        uses: ./.github/actions/dotnet/build
+        with:
+          configuration: ${{ inputs.configuration }}
+          no-restore: 'true'
+          working-directory: ${{ inputs.working-directory }}
+      
+      - name: Run tests
+        uses: ./.github/actions/dotnet/test
+        with:
+          configuration: ${{ inputs.configuration }}
+          no-build: 'true'
+          collect-coverage: ${{ inputs.collect-coverage }}
+          working-directory: ${{ inputs.working-directory }}
+      
+      - name: Publish test results
+        if: always()
+        uses: ./.github/actions/diagnostics/publish-test-results
+        with:
+          test-results-directory: TestResults
+      
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ inputs.runs-on }}
+          path: TestResults/**/*
+          retention-days: 30
+      
+      - name: Upload coverage reports
+        if: ${{ inputs.collect-coverage }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports-${{ inputs.runs-on }}
+          path: TestResults/**/coverage.cobertura.xml
+          retention-days: 30

--- a/.github/workflows/dotnet-library-release.yml
+++ b/.github/workflows/dotnet-library-release.yml
@@ -44,16 +44,125 @@ on:
         required: true
 
 jobs:
-  release:
-    name: Release Library
-    uses: ./.github/workflows/templates/stages/dotnet-library-release.yml
-    with:
-      dotnet-version: ${{ inputs.dotnet-version }}
-      configuration: ${{ inputs.configuration }}
-      runs-on: ${{ inputs.runs-on }}
-      working-directory: ${{ inputs.working-directory }}
-      project-path: ${{ inputs.project-path }}
-      nuget-source: ${{ inputs.nuget-source }}
-      skip-duplicate: ${{ inputs.skip-duplicate }}
-    secrets:
-      nuget-api-key: ${{ secrets.nuget-api-key }}
+  build-and-test:
+    name: Build and Test
+    runs-on: ${{ inputs.runs-on }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup .NET
+        uses: ./.github/actions/dotnet/setup
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+      
+      - name: Setup NuGet cache
+        uses: ./.github/actions/nuget/setup-cache
+        with:
+          working-directory: ${{ inputs.working-directory }}
+      
+      - name: Restore dependencies
+        uses: ./.github/actions/dotnet/restore
+        with:
+          working-directory: ${{ inputs.working-directory }}
+      
+      - name: Build solution
+        uses: ./.github/actions/dotnet/build
+        with:
+          configuration: ${{ inputs.configuration }}
+          no-restore: 'true'
+          working-directory: ${{ inputs.working-directory }}
+      
+      - name: Run tests
+        uses: ./.github/actions/dotnet/test
+        with:
+          configuration: ${{ inputs.configuration }}
+          no-build: 'true'
+          collect-coverage: 'true'
+          working-directory: ${{ inputs.working-directory }}
+      
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: TestResults/**/*
+          retention-days: 30
+  
+  code-quality:
+    name: Code Quality
+    runs-on: ${{ inputs.runs-on }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup .NET
+        uses: ./.github/actions/dotnet/setup
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+      
+      - name: Restore dependencies
+        uses: ./.github/actions/dotnet/restore
+        with:
+          working-directory: ${{ inputs.working-directory }}
+      
+      - name: Security vulnerability scan
+        uses: ./.github/actions/security/vulnerability-scan
+        with:
+          working-directory: ${{ inputs.working-directory }}
+          fail-on-severity: 'high'
+      
+      - name: Validate test naming
+        uses: ./.github/actions/diagnostics/validate-test-naming
+        with:
+          test-directory: ${{ inputs.working-directory }}
+  
+  publish:
+    name: Publish Package
+    needs: [build-and-test, code-quality]
+    runs-on: ${{ inputs.runs-on }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Setup .NET
+        uses: ./.github/actions/dotnet/setup
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+      
+      - name: Restore dependencies
+        uses: ./.github/actions/dotnet/restore
+      
+      - name: Build project
+        uses: ./.github/actions/dotnet/build
+        with:
+          configuration: ${{ inputs.configuration }}
+          no-restore: 'true'
+      
+      - name: Pack project
+        uses: ./.github/actions/dotnet/pack
+        with:
+          project-path: ${{ inputs.project-path }}
+          configuration: ${{ inputs.configuration }}
+          no-build: 'true'
+          output-directory: ./artifacts
+      
+      - name: Push to NuGet
+        uses: ./.github/actions/nuget/push
+        with:
+          package-path: './artifacts/*.nupkg'
+          source: ${{ inputs.nuget-source }}
+          api-key: ${{ secrets.nuget-api-key }}
+          skip-duplicate: ${{ inputs.skip-duplicate }}
+      
+      - name: Upload packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-packages
+          path: ./artifacts/*.nupkg
+          retention-days: 90

--- a/.github/workflows/dotnet-library-release.yml
+++ b/.github/workflows/dotnet-library-release.yml
@@ -1,0 +1,59 @@
+name: .NET Library Release (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      dotnet-version:
+        description: 'The .NET SDK version to use'
+        required: false
+        type: string
+        default: '10.0.x'
+      configuration:
+        description: 'Build configuration'
+        required: false
+        type: string
+        default: 'Release'
+      runs-on:
+        description: 'The runner to use'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      working-directory:
+        description: 'Working directory for operations'
+        required: false
+        type: string
+        default: '.'
+      project-path:
+        description: 'Path to the project to pack'
+        required: false
+        type: string
+        default: '.'
+      nuget-source:
+        description: 'NuGet feed URL'
+        required: false
+        type: string
+        default: 'https://api.nuget.org/v3/index.json'
+      skip-duplicate:
+        description: 'Skip if package version already exists'
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      nuget-api-key:
+        description: 'API key for the NuGet feed'
+        required: true
+
+jobs:
+  release:
+    name: Release Library
+    uses: ./.github/workflows/templates/stages/dotnet-library-release.yml
+    with:
+      dotnet-version: ${{ inputs.dotnet-version }}
+      configuration: ${{ inputs.configuration }}
+      runs-on: ${{ inputs.runs-on }}
+      working-directory: ${{ inputs.working-directory }}
+      project-path: ${{ inputs.project-path }}
+      nuget-source: ${{ inputs.nuget-source }}
+      skip-duplicate: ${{ inputs.skip-duplicate }}
+    secrets:
+      nuget-api-key: ${{ secrets.nuget-api-key }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,53 @@
+name: PR Validation (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      dotnet-version:
+        description: 'The .NET SDK version to use'
+        required: false
+        type: string
+        default: '10.0.x'
+      configuration:
+        description: 'Build configuration'
+        required: false
+        type: string
+        default: 'Release'
+      runs-on:
+        description: 'The runner to use'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      working-directory:
+        description: 'Working directory for operations'
+        required: false
+        type: string
+        default: '.'
+      enable-code-quality:
+        description: 'Run code quality checks'
+        required: false
+        type: boolean
+        default: true
+      post-pr-comment:
+        description: 'Post results as PR comment'
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      github-token:
+        description: 'GitHub token for posting comments'
+        required: false
+
+jobs:
+  validate:
+    name: Validate PR
+    uses: ./.github/workflows/templates/stages/pr-validation.yml
+    with:
+      dotnet-version: ${{ inputs.dotnet-version }}
+      configuration: ${{ inputs.configuration }}
+      runs-on: ${{ inputs.runs-on }}
+      working-directory: ${{ inputs.working-directory }}
+      enable-code-quality: ${{ inputs.enable-code-quality }}
+      post-pr-comment: ${{ inputs.post-pr-comment }}
+    secrets:
+      github-token: ${{ secrets.github-token }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -39,15 +39,123 @@ on:
         required: false
 
 jobs:
-  validate:
-    name: Validate PR
-    uses: ./.github/workflows/templates/stages/pr-validation.yml
-    with:
-      dotnet-version: ${{ inputs.dotnet-version }}
-      configuration: ${{ inputs.configuration }}
-      runs-on: ${{ inputs.runs-on }}
-      working-directory: ${{ inputs.working-directory }}
-      enable-code-quality: ${{ inputs.enable-code-quality }}
-      post-pr-comment: ${{ inputs.post-pr-comment }}
-    secrets:
-      github-token: ${{ secrets.github-token }}
+  build-and-test:
+    name: Build and Test
+    runs-on: ${{ inputs.runs-on }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup .NET
+        uses: ./.github/actions/dotnet/setup
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+      
+      - name: Setup NuGet cache
+        uses: ./.github/actions/nuget/setup-cache
+        with:
+          working-directory: ${{ inputs.working-directory }}
+      
+      - name: Restore dependencies
+        uses: ./.github/actions/dotnet/restore
+        with:
+          working-directory: ${{ inputs.working-directory }}
+      
+      - name: Build solution
+        uses: ./.github/actions/dotnet/build
+        with:
+          configuration: ${{ inputs.configuration }}
+          no-restore: 'true'
+          working-directory: ${{ inputs.working-directory }}
+      
+      - name: Run tests
+        uses: ./.github/actions/dotnet/test
+        with:
+          configuration: ${{ inputs.configuration }}
+          no-build: 'true'
+          collect-coverage: 'true'
+          working-directory: ${{ inputs.working-directory }}
+      
+      - name: Publish test results
+        if: always()
+        uses: ./.github/actions/diagnostics/publish-test-results
+        with:
+          test-results-directory: TestResults
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ inputs.runs-on }}
+          path: TestResults/**/*
+          retention-days: 30
+      
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports-${{ inputs.runs-on }}
+          path: TestResults/**/coverage.cobertura.xml
+          retention-days: 30
+  
+  code-quality:
+    name: Code Quality
+    if: ${{ inputs.enable-code-quality }}
+    runs-on: ${{ inputs.runs-on }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup .NET
+        uses: ./.github/actions/dotnet/setup
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+      
+      - name: Restore dependencies
+        uses: ./.github/actions/dotnet/restore
+        with:
+          working-directory: ${{ inputs.working-directory }}
+      
+      - name: Security vulnerability scan
+        uses: ./.github/actions/security/vulnerability-scan
+        with:
+          working-directory: ${{ inputs.working-directory }}
+          fail-on-severity: 'moderate'
+      
+      - name: Validate test naming
+        uses: ./.github/actions/diagnostics/validate-test-naming
+        with:
+          test-directory: ${{ inputs.working-directory }}
+      
+      - name: Check formatting (warn only)
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          dotnet format --verify-no-changes --verbosity diagnostic || echo "::warning::Code formatting issues detected. Run 'dotnet format' to fix."
+  
+  pr-summary:
+    name: PR Summary
+    needs: [build-and-test, code-quality]
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Generate PR summary
+        uses: ./.github/actions/pr/generate-summary
+      
+      - name: Post PR comment
+        if: ${{ inputs.post-pr-comment }}
+        uses: ./.github/actions/pr/post-comment
+        with:
+          github-token: ${{ secrets.github-token }}
+          message: |
+            ## ? PR Validation Complete
+            
+            Build and tests completed successfully!
+            
+            **Configuration:** ${{ inputs.configuration }}
+            **Runner:** ${{ inputs.runs-on }}
+            **Commit:** ${{ github.sha }}

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -41,13 +41,47 @@ on:
 jobs:
   publish:
     name: Publish Package
-    uses: ./.github/workflows/templates/jobs/publish-nuget.yml
-    with:
-      dotnet-version: ${{ inputs.dotnet-version }}
-      configuration: ${{ inputs.configuration }}
-      runs-on: ${{ inputs.runs-on }}
-      project-path: ${{ inputs.project-path }}
-      nuget-source: ${{ inputs.nuget-source }}
-      skip-duplicate: ${{ inputs.skip-duplicate }}
-    secrets:
-      nuget-api-key: ${{ secrets.nuget-api-key }}
+    runs-on: ${{ inputs.runs-on }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Setup .NET
+        uses: ./.github/actions/dotnet/setup
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+      
+      - name: Restore dependencies
+        uses: ./.github/actions/dotnet/restore
+      
+      - name: Build project
+        uses: ./.github/actions/dotnet/build
+        with:
+          configuration: ${{ inputs.configuration }}
+          no-restore: 'true'
+      
+      - name: Pack project
+        uses: ./.github/actions/dotnet/pack
+        with:
+          project-path: ${{ inputs.project-path }}
+          configuration: ${{ inputs.configuration }}
+          no-build: 'true'
+          output-directory: ./artifacts
+      
+      - name: Push to NuGet
+        uses: ./.github/actions/nuget/push
+        with:
+          package-path: './artifacts/*.nupkg'
+          source: ${{ inputs.nuget-source }}
+          api-key: ${{ secrets.nuget-api-key }}
+          skip-duplicate: ${{ inputs.skip-duplicate }}
+      
+      - name: Upload packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-packages
+          path: ./artifacts/*.nupkg
+          retention-days: 90

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,53 @@
+name: Publish NuGet Package (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      dotnet-version:
+        description: 'The .NET SDK version to use'
+        required: false
+        type: string
+        default: '10.0.x'
+      configuration:
+        description: 'Build configuration'
+        required: false
+        type: string
+        default: 'Release'
+      runs-on:
+        description: 'The runner to use'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      project-path:
+        description: 'Path to the project to pack'
+        required: false
+        type: string
+        default: '.'
+      nuget-source:
+        description: 'NuGet feed URL'
+        required: false
+        type: string
+        default: 'https://api.nuget.org/v3/index.json'
+      skip-duplicate:
+        description: 'Skip if package version already exists'
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      nuget-api-key:
+        description: 'API key for the NuGet feed'
+        required: true
+
+jobs:
+  publish:
+    name: Publish Package
+    uses: ./.github/workflows/templates/jobs/publish-nuget.yml
+    with:
+      dotnet-version: ${{ inputs.dotnet-version }}
+      configuration: ${{ inputs.configuration }}
+      runs-on: ${{ inputs.runs-on }}
+      project-path: ${{ inputs.project-path }}
+      nuget-source: ${{ inputs.nuget-source }}
+      skip-duplicate: ${{ inputs.skip-duplicate }}
+    secrets:
+      nuget-api-key: ${{ secrets.nuget-api-key }}


### PR DESCRIPTION
Added reusable workflows for CI/CD operations, including:
- `build-and-test.yml` for building/testing .NET projects
- `dotnet-library-release.yml` for releasing .NET libraries
- `pr-validation.yml` for validating pull requests
- `publish-nuget.yml` for publishing NuGet packages

Each workflow supports `workflow_call` for reusability and includes customizable inputs like `.NET SDK version`, `build configuration`, `runner`, and `working directory`. Default values are provided for ease of use, with optional features such as caching, test coverage, and code quality checks.

Secrets handling for sensitive data like `nuget-api-key` and `github-token` is included. Modular job templates in `.github/workflows/templates/` improve maintainability.