### PR TITLE
ci(workflows): centralize actions in shared repository

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: boolean
         default: true
+      actions-ref:
+        description: 'Git ref (branch/tag/commit) of HoneyDrunk.Actions to use'
+        required: false
+        type: string
+        default: 'main'
 
 jobs:
   build-and-test:
@@ -43,31 +48,38 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
+      - name: Checkout HoneyDrunk.Actions
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          path: .github/actions-repo
+          ref: ${{ inputs.actions-ref }}
+      
       - name: Setup .NET
-        uses: ./.github/actions/dotnet/setup
+        uses: ./.github/actions-repo/.github/actions/dotnet/setup
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
       
       - name: Setup NuGet cache
         if: ${{ inputs.enable-cache }}
-        uses: ./.github/actions/nuget/setup-cache
+        uses: ./.github/actions-repo/.github/actions/nuget/setup-cache
         with:
           working-directory: ${{ inputs.working-directory }}
       
       - name: Restore dependencies
-        uses: ./.github/actions/dotnet/restore
+        uses: ./.github/actions-repo/.github/actions/dotnet/restore
         with:
           working-directory: ${{ inputs.working-directory }}
       
       - name: Build solution
-        uses: ./.github/actions/dotnet/build
+        uses: ./.github/actions-repo/.github/actions/dotnet/build
         with:
           configuration: ${{ inputs.configuration }}
           no-restore: 'true'
           working-directory: ${{ inputs.working-directory }}
       
       - name: Run tests
-        uses: ./.github/actions/dotnet/test
+        uses: ./.github/actions-repo/.github/actions/dotnet/test
         with:
           configuration: ${{ inputs.configuration }}
           no-build: 'true'
@@ -76,7 +88,7 @@ jobs:
       
       - name: Publish test results
         if: always()
-        uses: ./.github/actions/diagnostics/publish-test-results
+        uses: ./.github/actions-repo/.github/actions/diagnostics/publish-test-results
         with:
           test-results-directory: TestResults
       

--- a/.github/workflows/dotnet-library-release.yml
+++ b/.github/workflows/dotnet-library-release.yml
@@ -38,6 +38,11 @@ on:
         required: false
         type: boolean
         default: true
+      actions-ref:
+        description: 'Git ref (branch/tag/commit) of HoneyDrunk.Actions to use'
+        required: false
+        type: string
+        default: 'main'
     secrets:
       nuget-api-key:
         description: 'API key for the NuGet feed'
@@ -52,30 +57,37 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
+      - name: Checkout HoneyDrunk.Actions
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          path: .github/actions-repo
+          ref: ${{ inputs.actions-ref }}
+      
       - name: Setup .NET
-        uses: ./.github/actions/dotnet/setup
+        uses: ./.github/actions-repo/.github/actions/dotnet/setup
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
       
       - name: Setup NuGet cache
-        uses: ./.github/actions/nuget/setup-cache
+        uses: ./.github/actions-repo/.github/actions/nuget/setup-cache
         with:
           working-directory: ${{ inputs.working-directory }}
       
       - name: Restore dependencies
-        uses: ./.github/actions/dotnet/restore
+        uses: ./.github/actions-repo/.github/actions/dotnet/restore
         with:
           working-directory: ${{ inputs.working-directory }}
       
       - name: Build solution
-        uses: ./.github/actions/dotnet/build
+        uses: ./.github/actions-repo/.github/actions/dotnet/build
         with:
           configuration: ${{ inputs.configuration }}
           no-restore: 'true'
           working-directory: ${{ inputs.working-directory }}
       
       - name: Run tests
-        uses: ./.github/actions/dotnet/test
+        uses: ./.github/actions-repo/.github/actions/dotnet/test
         with:
           configuration: ${{ inputs.configuration }}
           no-build: 'true'
@@ -98,24 +110,31 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
+      - name: Checkout HoneyDrunk.Actions
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          path: .github/actions-repo
+          ref: ${{ inputs.actions-ref }}
+      
       - name: Setup .NET
-        uses: ./.github/actions/dotnet/setup
+        uses: ./.github/actions-repo/.github/actions/dotnet/setup
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
       
       - name: Restore dependencies
-        uses: ./.github/actions/dotnet/restore
+        uses: ./.github/actions-repo/.github/actions/dotnet/restore
         with:
           working-directory: ${{ inputs.working-directory }}
       
       - name: Security vulnerability scan
-        uses: ./.github/actions/security/vulnerability-scan
+        uses: ./.github/actions-repo/.github/actions/security/vulnerability-scan
         with:
           working-directory: ${{ inputs.working-directory }}
           fail-on-severity: 'high'
       
       - name: Validate test naming
-        uses: ./.github/actions/diagnostics/validate-test-naming
+        uses: ./.github/actions-repo/.github/actions/diagnostics/validate-test-naming
         with:
           test-directory: ${{ inputs.working-directory }}
   
@@ -130,22 +149,29 @@ jobs:
         with:
           fetch-depth: 0
       
+      - name: Checkout HoneyDrunk.Actions
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          path: .github/actions-repo
+          ref: ${{ inputs.actions-ref }}
+      
       - name: Setup .NET
-        uses: ./.github/actions/dotnet/setup
+        uses: ./.github/actions-repo/.github/actions/dotnet/setup
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
       
       - name: Restore dependencies
-        uses: ./.github/actions/dotnet/restore
+        uses: ./.github/actions-repo/.github/actions/dotnet/restore
       
       - name: Build project
-        uses: ./.github/actions/dotnet/build
+        uses: ./.github/actions-repo/.github/actions/dotnet/build
         with:
           configuration: ${{ inputs.configuration }}
           no-restore: 'true'
       
       - name: Pack project
-        uses: ./.github/actions/dotnet/pack
+        uses: ./.github/actions-repo/.github/actions/dotnet/pack
         with:
           project-path: ${{ inputs.project-path }}
           configuration: ${{ inputs.configuration }}
@@ -153,7 +179,7 @@ jobs:
           output-directory: ./artifacts
       
       - name: Push to NuGet
-        uses: ./.github/actions/nuget/push
+        uses: ./.github/actions-repo/.github/actions/nuget/push
         with:
           package-path: './artifacts/*.nupkg'
           source: ${{ inputs.nuget-source }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: boolean
         default: false
+      actions-ref:
+        description: 'Git ref (branch/tag/commit) of HoneyDrunk.Actions to use'
+        required: false
+        type: string
+        default: 'main'
     secrets:
       github-token:
         description: 'GitHub token for posting comments'
@@ -47,30 +52,37 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
+      - name: Checkout HoneyDrunk.Actions
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          path: .github/actions-repo
+          ref: ${{ inputs.actions-ref }}
+      
       - name: Setup .NET
-        uses: ./.github/actions/dotnet/setup
+        uses: ./.github/actions-repo/.github/actions/dotnet/setup
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
       
       - name: Setup NuGet cache
-        uses: ./.github/actions/nuget/setup-cache
+        uses: ./.github/actions-repo/.github/actions/nuget/setup-cache
         with:
           working-directory: ${{ inputs.working-directory }}
       
       - name: Restore dependencies
-        uses: ./.github/actions/dotnet/restore
+        uses: ./.github/actions-repo/.github/actions/dotnet/restore
         with:
           working-directory: ${{ inputs.working-directory }}
       
       - name: Build solution
-        uses: ./.github/actions/dotnet/build
+        uses: ./.github/actions-repo/.github/actions/dotnet/build
         with:
           configuration: ${{ inputs.configuration }}
           no-restore: 'true'
           working-directory: ${{ inputs.working-directory }}
       
       - name: Run tests
-        uses: ./.github/actions/dotnet/test
+        uses: ./.github/actions-repo/.github/actions/dotnet/test
         with:
           configuration: ${{ inputs.configuration }}
           no-build: 'true'
@@ -79,7 +91,7 @@ jobs:
       
       - name: Publish test results
         if: always()
-        uses: ./.github/actions/diagnostics/publish-test-results
+        uses: ./.github/actions-repo/.github/actions/diagnostics/publish-test-results
         with:
           test-results-directory: TestResults
 
@@ -107,24 +119,31 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
+      - name: Checkout HoneyDrunk.Actions
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          path: .github/actions-repo
+          ref: ${{ inputs.actions-ref }}
+      
       - name: Setup .NET
-        uses: ./.github/actions/dotnet/setup
+        uses: ./.github/actions-repo/.github/actions/dotnet/setup
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
       
       - name: Restore dependencies
-        uses: ./.github/actions/dotnet/restore
+        uses: ./.github/actions-repo/.github/actions/dotnet/restore
         with:
           working-directory: ${{ inputs.working-directory }}
       
       - name: Security vulnerability scan
-        uses: ./.github/actions/security/vulnerability-scan
+        uses: ./.github/actions-repo/.github/actions/security/vulnerability-scan
         with:
           working-directory: ${{ inputs.working-directory }}
           fail-on-severity: 'moderate'
       
       - name: Validate test naming
-        uses: ./.github/actions/diagnostics/validate-test-naming
+        uses: ./.github/actions-repo/.github/actions/diagnostics/validate-test-naming
         with:
           test-directory: ${{ inputs.working-directory }}
       
@@ -143,12 +162,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
+      - name: Checkout HoneyDrunk.Actions
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          path: .github/actions-repo
+          ref: ${{ inputs.actions-ref }}
+      
       - name: Generate PR summary
-        uses: ./.github/actions/pr/generate-summary
+        uses: ./.github/actions-repo/.github/actions/pr/generate-summary
       
       - name: Post PR comment
         if: ${{ inputs.post-pr-comment }}
-        uses: ./.github/actions/pr/post-comment
+        uses: ./.github/actions-repo/.github/actions/pr/post-comment
         with:
           github-token: ${{ secrets.github-token }}
           message: |

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: boolean
         default: true
+      actions-ref:
+        description: 'Git ref (branch/tag/commit) of HoneyDrunk.Actions to use'
+        required: false
+        type: string
+        default: 'main'
     secrets:
       nuget-api-key:
         description: 'API key for the NuGet feed'
@@ -49,22 +54,29 @@ jobs:
         with:
           fetch-depth: 0
       
+      - name: Checkout HoneyDrunk.Actions
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          path: .github/actions-repo
+          ref: ${{ inputs.actions-ref }}
+      
       - name: Setup .NET
-        uses: ./.github/actions/dotnet/setup
+        uses: ./.github/actions-repo/.github/actions/dotnet/setup
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
       
       - name: Restore dependencies
-        uses: ./.github/actions/dotnet/restore
+        uses: ./.github/actions-repo/.github/actions/dotnet/restore
       
       - name: Build project
-        uses: ./.github/actions/dotnet/build
+        uses: ./.github/actions-repo/.github/actions/dotnet/build
         with:
           configuration: ${{ inputs.configuration }}
           no-restore: 'true'
       
       - name: Pack project
-        uses: ./.github/actions/dotnet/pack
+        uses: ./.github/actions-repo/.github/actions/dotnet/pack
         with:
           project-path: ${{ inputs.project-path }}
           configuration: ${{ inputs.configuration }}
@@ -72,7 +84,7 @@ jobs:
           output-directory: ./artifacts
       
       - name: Push to NuGet
-        uses: ./.github/actions/nuget/push
+        uses: ./.github/actions-repo/.github/actions/nuget/push
         with:
           package-path: './artifacts/*.nupkg'
           source: ${{ inputs.nuget-source }}


### PR DESCRIPTION
Replaced local actions with shared actions from the HoneyDrunk.Actions repository across multiple workflows (`build-and-test.yml`, `dotnet-library-release.yml`, `pr-validation.yml`, `publish-nuget.yml`) to improve maintainability and consistency.

- Added `actions-ref` input to specify Git ref for HoneyDrunk.Actions (default: `main`).
- Added step to check out HoneyDrunk.Actions repository.
- Updated all steps to use actions from HoneyDrunk.Actions.
- Added `Security vulnerability scan` and `Validate test naming` steps to `dotnet-library-release.yml` and `pr-validation.yml`.

These changes enhance reusability, simplify updates, and improve workflow functionality.