### PR TITLE
feat(workflows): add version override support for packaging

### DIFF
--- a/.github/actions/dotnet/pack/action.yml
+++ b/.github/actions/dotnet/pack/action.yml
@@ -14,11 +14,11 @@ inputs:
     required: false
     default: './artifacts'
   version:
-    description: 'Version to override in the package (e.g., 1.2.3)'
+    description: 'Full version to override (e.g., 1.2.3). Cannot be used with version-suffix.'
     required: false
     default: ''
   version-suffix:
-    description: 'Version suffix for the package'
+    description: 'Version suffix to append (e.g., beta.1). Cannot be used with version.'
     required: false
     default: ''
   no-build:
@@ -36,6 +36,12 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
+        # Validate that version and version-suffix are not both set
+        if [ -n "${{ inputs.version }}" ] && [ -n "${{ inputs.version-suffix }}" ]; then
+          echo "::error::Cannot specify both 'version' and 'version-suffix'. Use 'version' for full version override (e.g., 1.2.3) or 'version-suffix' to append to existing version (e.g., beta.1)."
+          exit 1
+        fi
+        
         ARGS="${{ inputs.project-path }} --configuration ${{ inputs.configuration }} --output ${{ inputs.output-directory }}"
         
         if [ "${{ inputs.no-build }}" == "true" ]; then

--- a/.github/actions/dotnet/pack/action.yml
+++ b/.github/actions/dotnet/pack/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Output directory for packages'
     required: false
     default: './artifacts'
+  version:
+    description: 'Version to override in the package (e.g., 1.2.3)'
+    required: false
+    default: ''
   version-suffix:
     description: 'Version suffix for the package'
     required: false
@@ -36,6 +40,10 @@ runs:
         
         if [ "${{ inputs.no-build }}" == "true" ]; then
           ARGS="$ARGS --no-build"
+        fi
+        
+        if [ -n "${{ inputs.version }}" ]; then
+          ARGS="$ARGS /p:Version=${{ inputs.version }}"
         fi
         
         if [ -n "${{ inputs.version-suffix }}" ]; then

--- a/.github/workflows/dotnet-library-release.yml
+++ b/.github/workflows/dotnet-library-release.yml
@@ -28,6 +28,11 @@ on:
         required: false
         type: string
         default: '.'
+      package-version:
+        description: 'Version to use for the NuGet package (overrides .csproj version)'
+        required: false
+        type: string
+        default: ''
       nuget-source:
         description: 'NuGet feed URL'
         required: false
@@ -185,6 +190,7 @@ jobs:
         with:
           project-path: ${{ inputs.project-path }}
           configuration: ${{ inputs.configuration }}
+          version: ${{ inputs.package-version }}
           no-build: 'true'
           output-directory: ./artifacts
           working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -28,6 +28,11 @@ on:
         required: false
         type: string
         default: '.'
+      package-version:
+        description: 'Version to use for the NuGet package (overrides .csproj version)'
+        required: false
+        type: string
+        default: ''
       nuget-source:
         description: 'NuGet feed URL'
         required: false
@@ -92,6 +97,7 @@ jobs:
         with:
           project-path: ${{ inputs.project-path }}
           configuration: ${{ inputs.configuration }}
+          version: ${{ inputs.package-version }}
           no-build: 'true'
           output-directory: ./artifacts
           working-directory: ${{ inputs.working-directory }}

--- a/examples/example-publish-with-version-override.yml
+++ b/examples/example-publish-with-version-override.yml
@@ -1,0 +1,103 @@
+# Example: Complete publish workflow for external repository with version override
+# This ensures the git tag version is used for all packages, regardless of .csproj versions
+
+name: Publish to NuGet
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (without v prefix, e.g., 0.1.1)'
+        required: true
+        type: string
+
+# Required permissions for publishing and creating releases
+permissions:
+  contents: write        # For creating GitHub releases
+  packages: write        # For publishing to NuGet
+  id-token: write        # For OIDC authentication (optional)
+
+jobs:
+  # Step 1: Extract version from git tag or manual input
+  prepare:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      version-tag: ${{ steps.get_version.outputs.version-tag }}
+    steps:
+      - name: Determine version
+        id: get_version
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ github.event.inputs.version }}"
+            VERSION_TAG="v${VERSION}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/v}"
+            VERSION_TAG="v${VERSION}"
+          fi
+          echo "version=$VERSION" >>"$GITHUB_OUTPUT"
+          echo "version-tag=$VERSION_TAG" >>"$GITHUB_OUTPUT"
+          echo "Publishing version: $VERSION"
+
+  # Step 2: Build, test, pack, and publish using reusable workflow
+  release:
+    name: Build, Pack & Publish
+    needs: prepare
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/dotnet-library-release.yml@main
+    with:
+      dotnet-version: '9.0.x'
+      configuration: 'Release'
+      runs-on: 'ubuntu-latest'
+      working-directory: '.'
+      project-path: 'HoneyDrunk.Standards/HoneyDrunk.Standards.csproj'
+      package-version: ${{ needs.prepare.outputs.version }}  # ? IMPORTANT: Override version from git tag
+      nuget-source: 'https://api.nuget.org/v3/index.json'
+      skip-duplicate: true
+      actions-ref: 'main'
+    secrets:
+      nuget-api-key: ${{ secrets.NUGET_API_KEY }}
+
+  # Step 3: Create GitHub Release with download links
+  github-release:
+    name: Create GitHub Release
+    needs: [prepare, release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.version-tag }}
+          name: Release ${{ needs.prepare.outputs.version-tag }}
+          body: |
+            ## Release ${{ needs.prepare.outputs.version-tag }}
+
+            ### Installation
+            ```xml
+            <PackageReference Include="YourPackage" Version="${{ needs.prepare.outputs.version }}" />
+            ```
+
+            ### What's New
+            <!-- Add release notes here -->
+
+            ### Links
+            - [NuGet Package](https://www.nuget.org/packages/YourPackage/${{ needs.prepare.outputs.version }})
+            - [Documentation](./README.md)
+            - [Changelog](./CHANGELOG.md)
+          draft: false
+          prerelease: false
+
+# Notes:
+# 1. The package-version input ensures all packages use the git tag version
+# 2. If .csproj has Version=0.1.0 but you tag v0.1.1, it will publish as 0.1.1
+# 3. skip-duplicate: true prevents errors if version already exists on NuGet
+# 4. Make sure NUGET_API_KEY is set in repository secrets


### PR DESCRIPTION
Introduce `version` and `package-version` inputs to enable overriding package versions during build and release workflows. Updated `action.yml`, `dotnet-library-release.yml`, and `publish-nuget.yml` to support version overrides. Added an example workflow (`example-publish-with-version-override.yml`) demonstrating version alignment with git tags. Improves consistency and flexibility in version management.