### PR TITLE
feat(ci): integrate external actions and add project-path input

### DIFF
--- a/.github/workflows/job-build-and-test.yml
+++ b/.github/workflows/job-build-and-test.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: string
         default: '.'
+      project-path:
+        description: 'Path to solution or project file (auto-detected if not specified)'
+        required: false
+        type: string
+        default: ''
       enable-cache:
         description: 'Enable NuGet package caching'
         required: false
@@ -33,6 +38,11 @@ on:
         required: false
         type: boolean
         default: true
+      actions-ref:
+        description: 'Git ref of HoneyDrunk.Actions to use'
+        required: false
+        type: string
+        default: 'main'
 
 jobs:
   build-and-test:
@@ -43,40 +53,50 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
+      - name: Checkout HoneyDrunk.Actions
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          path: .github/actions-repo
+          ref: ${{ inputs.actions-ref }}
+      
       - name: Setup .NET
-        uses: ./.github/actions/dotnet/setup
+        uses: ./.github/actions-repo/.github/actions/dotnet/setup
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
       
       - name: Setup NuGet cache
         if: ${{ inputs.enable-cache }}
-        uses: ./.github/actions/nuget/setup-cache
+        uses: ./.github/actions-repo/.github/actions/nuget/setup-cache
         with:
           working-directory: ${{ inputs.working-directory }}
       
       - name: Restore dependencies
-        uses: ./.github/actions/dotnet/restore
+        uses: ./.github/actions-repo/.github/actions/dotnet/restore
         with:
           working-directory: ${{ inputs.working-directory }}
+          project-path: ${{ inputs.project-path }}
       
       - name: Build solution
-        uses: ./.github/actions/dotnet/build
+        uses: ./.github/actions-repo/.github/actions/dotnet/build
         with:
           configuration: ${{ inputs.configuration }}
           no-restore: 'true'
           working-directory: ${{ inputs.working-directory }}
+          project-path: ${{ inputs.project-path }}
       
       - name: Run tests
-        uses: ./.github/actions/dotnet/test
+        uses: ./.github/actions-repo/.github/actions/dotnet/test
         with:
           configuration: ${{ inputs.configuration }}
           no-build: 'true'
           collect-coverage: ${{ inputs.collect-coverage }}
           working-directory: ${{ inputs.working-directory }}
+          project-path: ${{ inputs.project-path }}
       
       - name: Publish test results
         if: always()
-        uses: ./.github/actions/diagnostics/publish-test-results
+        uses: ./.github/actions-repo/.github/actions/diagnostics/publish-test-results
         with:
           test-results-directory: TestResults
       

--- a/.github/workflows/job-build-and-test.yml
+++ b/.github/workflows/job-build-and-test.yml
@@ -38,11 +38,6 @@ on:
         required: false
         type: boolean
         default: true
-      actions-ref:
-        description: 'Git ref of HoneyDrunk.Actions to use'
-        required: false
-        type: string
-        default: 'main'
 
 jobs:
   build-and-test:
@@ -53,32 +48,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
-        with:
-          repository: HoneyDrunkStudios/HoneyDrunk.Actions
-          path: .github/actions-repo
-          ref: ${{ inputs.actions-ref }}
-      
       - name: Setup .NET
-        uses: ./.github/actions-repo/.github/actions/dotnet/setup
+        uses: ./.github/actions/dotnet/setup
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
       
       - name: Setup NuGet cache
         if: ${{ inputs.enable-cache }}
-        uses: ./.github/actions-repo/.github/actions/nuget/setup-cache
+        uses: ./.github/actions/nuget/setup-cache
         with:
           working-directory: ${{ inputs.working-directory }}
       
       - name: Restore dependencies
-        uses: ./.github/actions-repo/.github/actions/dotnet/restore
+        uses: ./.github/actions/dotnet/restore
         with:
           working-directory: ${{ inputs.working-directory }}
           project-path: ${{ inputs.project-path }}
       
       - name: Build solution
-        uses: ./.github/actions-repo/.github/actions/dotnet/build
+        uses: ./.github/actions/dotnet/build
         with:
           configuration: ${{ inputs.configuration }}
           no-restore: 'true'
@@ -86,7 +74,7 @@ jobs:
           project-path: ${{ inputs.project-path }}
       
       - name: Run tests
-        uses: ./.github/actions-repo/.github/actions/dotnet/test
+        uses: ./.github/actions/dotnet/test
         with:
           configuration: ${{ inputs.configuration }}
           no-build: 'true'
@@ -96,7 +84,7 @@ jobs:
       
       - name: Publish test results
         if: always()
-        uses: ./.github/actions-repo/.github/actions/diagnostics/publish-test-results
+        uses: ./.github/actions/diagnostics/publish-test-results
         with:
           test-results-directory: TestResults
       

--- a/.github/workflows/job-secret-scan.yml
+++ b/.github/workflows/job-secret-scan.yml
@@ -30,12 +30,6 @@ on:
         required: false
         type: string
         default: ''
-      
-      actions-ref:
-        description: 'Git ref of HoneyDrunk.Actions to use'
-        required: false
-        type: string
-        default: 'main'
 
 permissions:
   contents: read

--- a/.github/workflows/job-static-analysis.yml
+++ b/.github/workflows/job-static-analysis.yml
@@ -61,12 +61,6 @@ on:
         required: false
         type: boolean
         default: true
-      
-      actions-ref:
-        description: 'Git ref of HoneyDrunk.Actions to use'
-        required: false
-        type: string
-        default: 'main'
 
 permissions:
   contents: read
@@ -80,20 +74,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       
-      - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
-        with:
-          repository: HoneyDrunkStudios/HoneyDrunk.Actions
-          path: .github/actions-repo
-          ref: ${{ inputs.actions-ref }}
-      
       - name: Setup .NET SDK
-        uses: ./.github/actions-repo/.github/actions/dotnet/setup
+        uses: ./.github/actions/dotnet/setup
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
       
       - name: Restore dependencies
-        uses: ./.github/actions-repo/.github/actions/dotnet/restore
+        uses: ./.github/actions/dotnet/restore
         with:
           working-directory: ${{ inputs.working-directory }}
           project-path: ${{ inputs.project-path }}
@@ -114,7 +101,7 @@ jobs:
           fi
       
       - name: Run vulnerability scan
-        uses: ./.github/actions-repo/.github/actions/security/vulnerability-scan
+        uses: ./.github/actions/security/vulnerability-scan
         with:
           working-directory: ${{ inputs.working-directory }}
           project-path: ${{ inputs.project-path }}
@@ -123,6 +110,6 @@ jobs:
       - name: Validate test naming conventions
         if: ${{ inputs.validate-test-naming }}
         continue-on-error: true
-        uses: ./.github/actions-repo/.github/actions/diagnostics/validate-test-naming
+        uses: ./.github/actions/diagnostics/validate-test-naming
         with:
           test-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/pr-core.yml
+++ b/.github/workflows/pr-core.yml
@@ -114,7 +114,6 @@ jobs:
       project-path: ${{ inputs.project-path }}
       enable-cache: true
       collect-coverage: false  # Coverage is for pr-sdk
-      actions-ref: ${{ inputs.actions-ref }}
     permissions:
       contents: read
       checks: write
@@ -132,7 +131,6 @@ jobs:
       fail-on-formatting-issues: false  # Warn only in PR
       fail-on-severity: 'high'
       validate-test-naming: true
-      actions-ref: ${{ inputs.actions-ref }}
     permissions:
       contents: read
   
@@ -144,7 +142,6 @@ jobs:
     with:
       runs-on: ${{ inputs.runs-on }}
       scan-mode: 'diff-only'
-      actions-ref: ${{ inputs.actions-ref }}
     permissions:
       contents: read
   


### PR DESCRIPTION
Introduce `project-path` and `actions-ref` inputs to enhance flexibility. Enable use of external `HoneyDrunk.Actions` repository for modular workflows. Update steps to reference actions from `.github/actions-repo`. Improve support for specifying solution or project file paths.