### PR TITLE
chore(ci): modularize workflows with centralized actions

### DIFF
--- a/.github/workflows/job-build-and-test.yml
+++ b/.github/workflows/job-build-and-test.yml
@@ -38,6 +38,11 @@ on:
         required: false
         type: boolean
         default: true
+      actions-ref:
+        description: 'Git ref of HoneyDrunk.Actions to use (should match the version of this workflow)'
+        required: false
+        type: string
+        default: 'main'
 
 jobs:
   build-and-test:
@@ -48,25 +53,32 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
+      - name: Checkout HoneyDrunk.Actions
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          path: .github/actions-repo
+          ref: ${{ inputs.actions-ref }}
+      
       - name: Setup .NET
-        uses: ./.github/actions/dotnet/setup
+        uses: ./.github/actions-repo/.github/actions/dotnet/setup
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
       
       - name: Setup NuGet cache
         if: ${{ inputs.enable-cache }}
-        uses: ./.github/actions/nuget/setup-cache
+        uses: ./.github/actions-repo/.github/actions/nuget/setup-cache
         with:
           working-directory: ${{ inputs.working-directory }}
       
       - name: Restore dependencies
-        uses: ./.github/actions/dotnet/restore
+        uses: ./.github/actions-repo/.github/actions/dotnet/restore
         with:
           working-directory: ${{ inputs.working-directory }}
           project-path: ${{ inputs.project-path }}
       
       - name: Build solution
-        uses: ./.github/actions/dotnet/build
+        uses: ./.github/actions-repo/.github/actions/dotnet/build
         with:
           configuration: ${{ inputs.configuration }}
           no-restore: 'true'
@@ -74,7 +86,7 @@ jobs:
           project-path: ${{ inputs.project-path }}
       
       - name: Run tests
-        uses: ./.github/actions/dotnet/test
+        uses: ./.github/actions-repo/.github/actions/dotnet/test
         with:
           configuration: ${{ inputs.configuration }}
           no-build: 'true'
@@ -84,7 +96,7 @@ jobs:
       
       - name: Publish test results
         if: always()
-        uses: ./.github/actions/diagnostics/publish-test-results
+        uses: ./.github/actions-repo/.github/actions/diagnostics/publish-test-results
         with:
           test-results-directory: TestResults
       

--- a/.github/workflows/job-static-analysis.yml
+++ b/.github/workflows/job-static-analysis.yml
@@ -61,6 +61,12 @@ on:
         required: false
         type: boolean
         default: true
+      
+      actions-ref:
+        description: 'Git ref of HoneyDrunk.Actions to use (should match the version of this workflow)'
+        required: false
+        type: string
+        default: 'main'
 
 permissions:
   contents: read
@@ -74,13 +80,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       
+      - name: Checkout HoneyDrunk.Actions
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          path: .github/actions-repo
+          ref: ${{ inputs.actions-ref }}
+      
       - name: Setup .NET SDK
-        uses: ./.github/actions/dotnet/setup
+        uses: ./.github/actions-repo/.github/actions/dotnet/setup
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
       
       - name: Restore dependencies
-        uses: ./.github/actions/dotnet/restore
+        uses: ./.github/actions-repo/.github/actions/dotnet/restore
         with:
           working-directory: ${{ inputs.working-directory }}
           project-path: ${{ inputs.project-path }}
@@ -92,7 +105,7 @@ jobs:
         run: |
           echo "Checking code formatting..."
           if ! dotnet format --verify-no-changes --verbosity diagnostic; then
-            if [ "${{ inputs.fail-on-formatting-issues }}" == "true" ]; then
+            if [ "${{ inputs.fail-on-formatting-issues }}" = "true" ]; then
               echo "::error::Code formatting issues detected. Run 'dotnet format' to fix."
               exit 1
             else
@@ -101,7 +114,7 @@ jobs:
           fi
       
       - name: Run vulnerability scan
-        uses: ./.github/actions/security/vulnerability-scan
+        uses: ./.github/actions-repo/.github/actions/security/vulnerability-scan
         with:
           working-directory: ${{ inputs.working-directory }}
           project-path: ${{ inputs.project-path }}
@@ -110,6 +123,6 @@ jobs:
       - name: Validate test naming conventions
         if: ${{ inputs.validate-test-naming }}
         continue-on-error: true
-        uses: ./.github/actions/diagnostics/validate-test-naming
+        uses: ./.github/actions-repo/.github/actions/diagnostics/validate-test-naming
         with:
           test-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/pr-core.yml
+++ b/.github/workflows/pr-core.yml
@@ -114,6 +114,7 @@ jobs:
       project-path: ${{ inputs.project-path }}
       enable-cache: true
       collect-coverage: false  # Coverage is for pr-sdk
+      actions-ref: ${{ inputs.actions-ref }}
     permissions:
       contents: read
       checks: write
@@ -131,6 +132,7 @@ jobs:
       fail-on-formatting-issues: false  # Warn only in PR
       fail-on-severity: 'high'
       validate-test-naming: true
+      actions-ref: ${{ inputs.actions-ref }}
     permissions:
       contents: read
   


### PR DESCRIPTION
Modularize GitHub workflows to source custom actions from the HoneyDrunk.Actions repository. Added `actions-ref` input to `job-build-and-test.yml`, `job-static-analysis.yml`, and `pr-core.yml` to specify the Git reference for the actions repository. Updated workflows to check out the actions repository and reference actions from `.github/actions-repo`.

Aligned `job-static-analysis.yml` with POSIX shell compatibility by using `=` for string comparison. Standardized `actions-ref` usage across workflows for consistency. Improved maintainability and reusability of CI/CD workflows.