### PR TITLE
Add reusable Hive field-mirroring workflow, repo→node mapping, and backfill scripts (ADR-0008 D4)

### DIFF
--- a/.github/config/repo-to-node.yml
+++ b/.github/config/repo-to-node.yml
@@ -10,3 +10,4 @@ HoneyDrunk.Notify: honeydrunk-notify
 HoneyDrunk.Actions: honeydrunk-actions
 HoneyDrunk.Architecture: honeydrunk-architecture
 HoneyDrunkStudios: honeydrunk-studios
+HoneyDrunk.Lore: honeydrunk-lore

--- a/.github/config/repo-to-node.yml
+++ b/.github/config/repo-to-node.yml
@@ -1,0 +1,12 @@
+HoneyDrunk.Kernel: honeydrunk-kernel
+HoneyDrunk.Transport: honeydrunk-transport
+HoneyDrunk.Vault: honeydrunk-vault
+HoneyDrunk.Vault.Rotation: honeydrunk-vault
+HoneyDrunk.Auth: honeydrunk-auth
+HoneyDrunk.Web.Rest: honeydrunk-web-rest
+HoneyDrunk.Data: honeydrunk-data
+HoneyDrunk.Pulse: pulse
+HoneyDrunk.Notify: honeydrunk-notify
+HoneyDrunk.Actions: honeydrunk-actions
+HoneyDrunk.Architecture: honeydrunk-architecture
+HoneyDrunkStudios: honeydrunk-studios

--- a/.github/workflows/hive-field-mirror.yml
+++ b/.github/workflows/hive-field-mirror.yml
@@ -1,0 +1,70 @@
+name: Hive Field Mirror
+
+on:
+  issues:
+    types: [opened, labeled, unlabeled, edited]
+  workflow_call:
+    inputs:
+      project-owner:
+        description: GitHub org/user that owns the project.
+        required: false
+        type: string
+        default: HoneyDrunkStudios
+      project-number:
+        description: Project v2 number.
+        required: false
+        type: number
+        default: 4
+      issue-url:
+        description: Optional issue URL override for manual dispatchers.
+        required: false
+        type: string
+    secrets:
+      hive-field-mirror-token:
+        description: Token with issues read + organization projects write scopes.
+        required: false
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout actions repository
+        uses: actions/checkout@v4
+
+      - name: Resolve issue URL
+        id: issue
+        env:
+          INPUT_ISSUE_URL: ${{ inputs.issue-url || '' }}
+          EVENT_ISSUE_URL: ${{ github.event.issue.html_url || '' }}
+        run: |
+          set -euo pipefail
+          ISSUE_URL="${INPUT_ISSUE_URL}"
+          if [[ -z "${ISSUE_URL}" ]]; then
+            ISSUE_URL="${EVENT_ISSUE_URL}"
+          fi
+          if [[ -z "${ISSUE_URL}" ]]; then
+            echo "No issue URL available from workflow_call input or issues event payload." >&2
+            exit 1
+          fi
+          echo "issue_url=${ISSUE_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Mirror labels to The Hive custom fields
+        env:
+          PROJECT_OWNER: ${{ inputs.project-owner || 'HoneyDrunkStudios' }}
+          PROJECT_NUMBER: ${{ inputs.project-number || 4 }}
+          HIVE_FIELD_MIRROR_TOKEN: ${{ secrets.hive-field-mirror-token || secrets.HIVE_FIELD_MIRROR_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${HIVE_FIELD_MIRROR_TOKEN}" ]]; then
+            echo "HIVE_FIELD_MIRROR_TOKEN is not configured." >&2
+            exit 1
+          fi
+          ./scripts/hive-project-mirror.sh \
+            --url "${{ steps.issue.outputs.issue_url }}" \
+            --project-owner "${PROJECT_OWNER}" \
+            --project-number "${PROJECT_NUMBER}" \
+            --mapping-file .github/config/repo-to-node.yml

--- a/.github/workflows/hive-field-mirror.yml
+++ b/.github/workflows/hive-field-mirror.yml
@@ -57,14 +57,16 @@ jobs:
           PROJECT_OWNER: ${{ inputs.project-owner || 'HoneyDrunkStudios' }}
           PROJECT_NUMBER: ${{ inputs.project-number || 4 }}
           HIVE_FIELD_MIRROR_TOKEN: ${{ secrets.hive-field-mirror-token || secrets.HIVE_FIELD_MIRROR_TOKEN }}
+          ISSUE_URL: ${{ steps.issue.outputs.issue_url }}
         run: |
           set -euo pipefail
           if [[ -z "${HIVE_FIELD_MIRROR_TOKEN}" ]]; then
             echo "HIVE_FIELD_MIRROR_TOKEN is not configured." >&2
             exit 1
           fi
+          # Token may come from workflow_call secret or repo/org secret fallback.
           ./scripts/hive-project-mirror.sh \
-            --url "${{ steps.issue.outputs.issue_url }}" \
+            --url "${ISSUE_URL}" \
             --project-owner "${PROJECT_OWNER}" \
             --project-number "${PROJECT_NUMBER}" \
             --mapping-file .github/config/repo-to-node.yml

--- a/.github/workflows/hive-field-mirror.yml
+++ b/.github/workflows/hive-field-mirror.yml
@@ -19,6 +19,11 @@ on:
         description: Optional issue URL override for manual dispatchers.
         required: false
         type: string
+      actions-ref:
+        description: Ref (branch/tag/SHA) of HoneyDrunk.Actions to checkout for scripts/config.
+        required: false
+        type: string
+        default: main
     secrets:
       hive-field-mirror-token:
         description: Token with issues read + organization projects write scopes.
@@ -32,8 +37,12 @@ jobs:
   mirror:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout actions repository
+      - name: Checkout HoneyDrunk.Actions repository
         uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          ref: ${{ inputs.actions-ref || 'main' }}
+          path: honeydrunk-actions
 
       - name: Resolve issue URL
         id: issue
@@ -65,8 +74,8 @@ jobs:
             exit 1
           fi
           # Token may come from workflow_call secret or repo/org secret fallback.
-          ./scripts/hive-project-mirror.sh \
+          ./honeydrunk-actions/scripts/hive-project-mirror.sh \
             --url "${ISSUE_URL}" \
             --project-owner "${PROJECT_OWNER}" \
             --project-number "${PROJECT_NUMBER}" \
-            --mapping-file .github/config/repo-to-node.yml
+            --mapping-file ./honeydrunk-actions/.github/config/repo-to-node.yml

--- a/.github/workflows/hive-field-mirror.yml
+++ b/.github/workflows/hive-field-mirror.yml
@@ -27,7 +27,7 @@ on:
     secrets:
       hive-field-mirror-token:
         description: Token with issues read + organization projects write scopes.
-        required: false
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/hive-field-mirror.yml
+++ b/.github/workflows/hive-field-mirror.yml
@@ -20,10 +20,10 @@ on:
         required: false
         type: string
       actions-ref:
-        description: Ref (branch/tag/SHA) of HoneyDrunk.Actions to checkout for scripts/config.
+        description: Ref (branch/tag/SHA) of HoneyDrunk.Actions to checkout for scripts/config. Defaults to the called workflow ref derived from GITHUB_WORKFLOW_REF so scripts/config stay in sync with the pinned workflow version.
         required: false
         type: string
-        default: main
+        default: ''
     secrets:
       hive-field-mirror-token:
         description: Token with issues read + organization projects write scopes.
@@ -37,11 +37,24 @@ jobs:
   mirror:
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve actions checkout ref
+        id: resolve-ref
+        run: |
+          set -euo pipefail
+          INPUT_REF="${{ inputs.actions-ref }}"
+          if [[ -n "${INPUT_REF}" ]]; then
+            echo "ref=${INPUT_REF}" >> "$GITHUB_OUTPUT"
+          else
+            # Derive ref from the called workflow's own ref so scripts/config stay in sync
+            # GITHUB_WORKFLOW_REF format: owner/repo/path/to/workflow.yml@refs/heads/main
+            echo "ref=${GITHUB_WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout HoneyDrunk.Actions repository
         uses: actions/checkout@v4
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
-          ref: ${{ github.event_name == 'workflow_call' && inputs.actions-ref || 'main' }}
+          ref: ${{ steps.resolve-ref.outputs.ref }}
           path: honeydrunk-actions
 
       - name: Resolve issue URL

--- a/.github/workflows/hive-field-mirror.yml
+++ b/.github/workflows/hive-field-mirror.yml
@@ -41,13 +41,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
-          ref: ${{ inputs.actions-ref || 'main' }}
+          ref: ${{ github.event_name == 'workflow_call' && inputs.actions-ref || 'main' }}
           path: honeydrunk-actions
 
       - name: Resolve issue URL
         id: issue
         env:
-          INPUT_ISSUE_URL: ${{ inputs.issue-url || '' }}
+          INPUT_ISSUE_URL: ${{ github.event_name == 'workflow_call' && inputs.issue-url || '' }}
           EVENT_ISSUE_URL: ${{ github.event.issue.html_url || '' }}
         run: |
           set -euo pipefail
@@ -63,8 +63,8 @@ jobs:
 
       - name: Mirror labels to The Hive custom fields
         env:
-          PROJECT_OWNER: ${{ inputs.project-owner || 'HoneyDrunkStudios' }}
-          PROJECT_NUMBER: ${{ inputs.project-number || 4 }}
+          PROJECT_OWNER: ${{ github.event_name == 'workflow_call' && inputs.project-owner || 'HoneyDrunkStudios' }}
+          PROJECT_NUMBER: ${{ github.event_name == 'workflow_call' && inputs.project-number || 4 }}
           HIVE_FIELD_MIRROR_TOKEN: ${{ secrets.hive-field-mirror-token || secrets.HIVE_FIELD_MIRROR_TOKEN }}
           ISSUE_URL: ${{ steps.issue.outputs.issue_url }}
         run: |

--- a/README.md
+++ b/README.md
@@ -534,6 +534,7 @@ Inputs:
 - `project-owner` (default: `HoneyDrunkStudios`)
 - `project-number` (default: `4`)
 - `issue-url` (optional override for callers)
+- `actions-ref` (optional; defaults to the ref the workflow was pinned at via `GITHUB_WORKFLOW_REF`, so scripts and config automatically stay aligned with the pinned workflow version — only override if you need to test a different ref)
 
 Secret:
 - `HIVE_FIELD_MIRROR_TOKEN` (or pass as `hive-field-mirror-token` in `workflow_call`)

--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ on:
 
 jobs:
   mirror:
-    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/hive-field-mirror.yml@main
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/hive-field-mirror.yml@v1
     secrets:
       hive-field-mirror-token: ${{ secrets.HIVE_FIELD_MIRROR_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -509,3 +509,76 @@ This project is licensed under the terms specified in the [LICENSE](LICENSE) fil
 ---
 
 **HoneyDrunk Studios** - Building better CI/CD pipelines, one action at a time.
+
+## 🐝 The Hive Field Mirror (ADR-0008 D4)
+
+`hive-field-mirror.yml` is a reusable workflow that mirrors issue labels into custom fields on **The Hive** (GitHub Project v2 #4).
+
+### What it updates
+
+| Source | Project field | Behavior |
+| --- | --- | --- |
+| `wave-1`, `wave-2`, `wave-3` | `Wave` (single select) | Maps to `Wave 1`, `Wave 2`, `Wave 3`; if none present sets `N/A`. |
+| `adr-####` labels | `ADR` (text) | Writes uppercase, comma-separated labels (example: `ADR-0005, ADR-0008`). |
+| `tier-1`, `tier-2`, `tier-3` | `Tier` (single select) | Direct mapping when present. If absent, the workflow leaves Tier unchanged. |
+| Repository name | `Node` (single select) | Uses `.github/config/repo-to-node.yml` lookup. |
+| `initiative-<slug>` | `Initiative` (single select) | Optional. Set only when label exists and option exists on the field. |
+
+The workflow intentionally **does not modify `Status`**.
+
+### Reusable workflow contract
+
+Workflow: `.github/workflows/hive-field-mirror.yml`
+
+Inputs:
+- `project-owner` (default: `HoneyDrunkStudios`)
+- `project-number` (default: `4`)
+- `issue-url` (optional override for callers)
+
+Secret:
+- `HIVE_FIELD_MIRROR_TOKEN` (or pass as `hive-field-mirror-token` in `workflow_call`)
+
+### Enable in a consuming repo
+
+Add `.github/workflows/hive-mirror.yml`:
+
+```yaml
+name: Hive Mirror
+
+on:
+  issues:
+    types: [opened, labeled, unlabeled, edited]
+
+jobs:
+  mirror:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/hive-field-mirror.yml@main
+    secrets:
+      hive-field-mirror-token: ${{ secrets.HIVE_FIELD_MIRROR_TOKEN }}
+```
+
+### Node lookup maintenance
+
+Update `.github/config/repo-to-node.yml` whenever a new repo/node is introduced.
+
+Format:
+
+```yaml
+Repository.Name: node-option-slug
+```
+
+### Token rotation
+
+1. Create a new fine-grained GitHub App/PAT token with:
+   - Issues read access on target repos.
+   - Organization Projects write access on `HoneyDrunkStudios`.
+2. Replace org secret `HIVE_FIELD_MIRROR_TOKEN`.
+3. Trigger the mirror workflow on a test issue to verify updates.
+4. Revoke old token.
+
+### One-off backfill
+
+Use `scripts/hive-backfill-issue.sh` to mirror one issue manually:
+
+```bash
+HIVE_FIELD_MIRROR_TOKEN=*** ./scripts/hive-backfill-issue.sh --url https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/issues/123
+```

--- a/scripts/hive-backfill-issue.sh
+++ b/scripts/hive-backfill-issue.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_OWNER="HoneyDrunkStudios"
+PROJECT_NUMBER="4"
+ISSUE_URL=""
+
+usage() {
+  cat <<'USAGE'
+Usage: hive-backfill-issue.sh --url <issue-url> [--project-owner <owner>] [--project-number <number>]
+
+Environment:
+  HIVE_FIELD_MIRROR_TOKEN  GitHub token with repository issues read + org project write.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --url) ISSUE_URL="$2"; shift 2 ;;
+    --project-owner) PROJECT_OWNER="$2"; shift 2 ;;
+    --project-number) PROJECT_NUMBER="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$ISSUE_URL" ]]; then
+  echo "--url is required" >&2
+  usage
+  exit 1
+fi
+
+"${SCRIPT_DIR}/hive-project-mirror.sh" \
+  --url "$ISSUE_URL" \
+  --project-owner "$PROJECT_OWNER" \
+  --project-number "$PROJECT_NUMBER"

--- a/scripts/hive-backfill-issue.sh
+++ b/scripts/hive-backfill-issue.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_OWNER="HoneyDrunkStudios"
 PROJECT_NUMBER="4"
 ISSUE_URL=""
+MAPPING_FILE="${SCRIPT_DIR}/../.github/config/repo-to-node.yml"
 
 usage() {
   cat <<'USAGE'
@@ -34,4 +35,5 @@ fi
 "${SCRIPT_DIR}/hive-project-mirror.sh" \
   --url "$ISSUE_URL" \
   --project-owner "$PROJECT_OWNER" \
-  --project-number "$PROJECT_NUMBER"
+  --project-number "$PROJECT_NUMBER" \
+  --mapping-file "$MAPPING_FILE"

--- a/scripts/hive-project-mirror.sh
+++ b/scripts/hive-project-mirror.sh
@@ -122,7 +122,43 @@ if [[ -z "$PROJECT_ID" || "$PROJECT_ID" == "null" ]]; then
 fi
 
 add_item_query='mutation($project:ID!, $content:ID!) { addProjectV2ItemById(input:{projectId:$project, contentId:$content}) { item { id } } }'
-ITEM_ID="$(gh api graphql -f query="$add_item_query" -f project="$PROJECT_ID" -f content="$ISSUE_NODE_ID" --jq '.data.addProjectV2ItemById.item.id')"
+
+ITEM_ID=""
+set +e
+ADD_ITEM_OUTPUT="$(gh api graphql -f query="$add_item_query" -f project="$PROJECT_ID" -f content="$ISSUE_NODE_ID" 2>&1)"
+ADD_ITEM_EXIT_CODE=$?
+set -e
+
+if [[ $ADD_ITEM_EXIT_CODE -eq 0 ]]; then
+  ITEM_ID="$(jq -r '.data.addProjectV2ItemById.item.id // empty' <<<"$ADD_ITEM_OUTPUT")"
+else
+  echo "::warning::addProjectV2ItemById failed; attempting existing item lookup."
+fi
+
+if [[ -z "$ITEM_ID" ]]; then
+  lookup_query='query($project: ID!, $after: String) { node(id: $project) { ... on ProjectV2 { items(first: 100, after: $after) { nodes { id content { ... on Issue { id } } } pageInfo { hasNextPage endCursor } } } } }'
+  HAS_NEXT_PAGE="true"
+  END_CURSOR=""
+  while [[ "$HAS_NEXT_PAGE" == "true" && -z "$ITEM_ID" ]]; do
+    if [[ -n "$END_CURSOR" ]]; then
+      LOOKUP_JSON="$(gh api graphql -f query="$lookup_query" -f project="$PROJECT_ID" -f after="$END_CURSOR")"
+    else
+      LOOKUP_JSON="$(gh api graphql -f query="$lookup_query" -f project="$PROJECT_ID")"
+    fi
+
+    ITEM_ID="$(jq -r --arg issue_id "$ISSUE_NODE_ID" '.data.node.items.nodes[] | select(.content.id == $issue_id) | .id' <<<"$LOOKUP_JSON" | head -n1)"
+    HAS_NEXT_PAGE="$(jq -r '.data.node.items.pageInfo.hasNextPage' <<<"$LOOKUP_JSON")"
+    END_CURSOR="$(jq -r '.data.node.items.pageInfo.endCursor // empty' <<<"$LOOKUP_JSON")"
+  done
+fi
+
+if [[ -z "$ITEM_ID" ]]; then
+  echo "Failed to resolve project item ID for issue node ${ISSUE_NODE_ID}" >&2
+  if [[ $ADD_ITEM_EXIT_CODE -ne 0 ]]; then
+    echo "addProjectV2ItemById error output: $ADD_ITEM_OUTPUT" >&2
+  fi
+  exit 1
+fi
 
 FIELDS_JSON="$(gh project field-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json)"
 

--- a/scripts/hive-project-mirror.sh
+++ b/scripts/hive-project-mirror.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_OWNER="HoneyDrunkStudios"
+PROJECT_NUMBER="4"
+ISSUE_URL=""
+TOKEN="${HIVE_FIELD_MIRROR_TOKEN:-${GH_TOKEN:-}}"
+MAPPING_FILE=".github/config/repo-to-node.yml"
+
+usage() {
+  cat <<'USAGE'
+Usage: hive-project-mirror.sh --url <issue-url> [--project-owner <owner>] [--project-number <number>] [--mapping-file <path>] [--token <token>]
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --url) ISSUE_URL="$2"; shift 2 ;;
+    --project-owner) PROJECT_OWNER="$2"; shift 2 ;;
+    --project-number) PROJECT_NUMBER="$2"; shift 2 ;;
+    --mapping-file) MAPPING_FILE="$2"; shift 2 ;;
+    --token) TOKEN="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$ISSUE_URL" ]]; then
+  echo "--url is required" >&2
+  exit 1
+fi
+
+if [[ -z "$TOKEN" ]]; then
+  echo "HIVE_FIELD_MIRROR_TOKEN (or GH_TOKEN) must be set" >&2
+  exit 1
+fi
+
+export GH_TOKEN="$TOKEN"
+
+if [[ ! "$ISSUE_URL" =~ ^https://github.com/([^/]+)/([^/]+)/issues/([0-9]+)$ ]]; then
+  echo "Invalid issue URL: $ISSUE_URL" >&2
+  exit 1
+fi
+
+ISSUE_OWNER="${BASH_REMATCH[1]}"
+ISSUE_REPO="${BASH_REMATCH[2]}"
+ISSUE_NUMBER="${BASH_REMATCH[3]}"
+
+if [[ ! -f "$MAPPING_FILE" ]]; then
+  echo "Mapping file not found: $MAPPING_FILE" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh is required" >&2
+  exit 1
+fi
+
+ISSUE_JSON="$(gh api "repos/${ISSUE_OWNER}/${ISSUE_REPO}/issues/${ISSUE_NUMBER}")"
+ISSUE_NODE_ID="$(jq -r '.node_id' <<<"$ISSUE_JSON")"
+if [[ -z "$ISSUE_NODE_ID" || "$ISSUE_NODE_ID" == "null" ]]; then
+  echo "Could not resolve issue node ID" >&2
+  exit 1
+fi
+
+mapfile -t LABELS < <(jq -r '.labels[].name' <<<"$ISSUE_JSON" | tr '[:upper:]' '[:lower:]')
+
+WAVE_LABEL=""
+TIER_LABEL=""
+INITIATIVE_SLUG=""
+ADR_LABELS=()
+
+for label in "${LABELS[@]:-}"; do
+  case "$label" in
+    wave-1|wave-2|wave-3) WAVE_LABEL="$label" ;;
+    tier-1|tier-2|tier-3) TIER_LABEL="$label" ;;
+    adr-[0-9][0-9][0-9][0-9]) ADR_LABELS+=("${label^^}") ;;
+    initiative-*) INITIATIVE_SLUG="${label#initiative-}" ;;
+  esac
+done
+
+ADR_TEXT=""
+if [[ ${#ADR_LABELS[@]} -gt 0 ]]; then
+  IFS=$'\n' read -r -d '' -a ADR_SORTED < <(printf '%s\n' "${ADR_LABELS[@]}" | sort -u && printf '\0')
+  ADR_TEXT="$(IFS=', '; echo "${ADR_SORTED[*]}")"
+fi
+
+NODE_OPTION="$(python3 - <<'PY' "$MAPPING_FILE" "$ISSUE_REPO"
+import sys
+mapping_path, repo_name = sys.argv[1], sys.argv[2]
+value = ""
+with open(mapping_path, encoding="utf-8") as f:
+    for line in f:
+        s = line.strip()
+        if not s or s.startswith('#'):
+            continue
+        if ':' not in s:
+            continue
+        key, val = s.split(':', 1)
+        if key.strip() == repo_name:
+            value = val.strip()
+            break
+print(value)
+PY
+)"
+
+PROJECT_JSON="$(gh project view "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json)"
+PROJECT_ID="$(jq -r '.id' <<<"$PROJECT_JSON")"
+if [[ -z "$PROJECT_ID" || "$PROJECT_ID" == "null" ]]; then
+  echo "Failed to resolve project id for ${PROJECT_OWNER}/${PROJECT_NUMBER}" >&2
+  exit 1
+fi
+
+add_item_query='mutation($project:ID!, $content:ID!) { addProjectV2ItemById(input:{projectId:$project, contentId:$content}) { item { id } } }'
+ITEM_ID="$(gh api graphql -f query="$add_item_query" -f project="$PROJECT_ID" -f content="$ISSUE_NODE_ID" --jq '.data.addProjectV2ItemById.item.id')"
+
+FIELDS_JSON="$(gh project field-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json)"
+
+get_field_id() {
+  local name="$1"
+  jq -r --arg name "$name" '.fields[] | select(.name == $name) | .id' <<<"$FIELDS_JSON" | head -n1
+}
+
+get_single_option_id() {
+  local field_name="$1"
+  local option_name="$2"
+  jq -r --arg field "$field_name" --arg option "$option_name" '
+    .fields[]
+    | select(.name == $field)
+    | .options[]?
+    | select(.name == $option)
+    | .id
+  ' <<<"$FIELDS_JSON" | head -n1
+}
+
+update_single_select() {
+  local field_id="$1"
+  local option_id="$2"
+  local label="$3"
+  if [[ -z "$field_id" || -z "$option_id" ]]; then
+    echo "::warning::Skipping ${label}; missing field/option id"
+    return 0
+  fi
+  local query='mutation($project:ID!, $item:ID!, $field:ID!, $option:String!) { updateProjectV2ItemFieldValue(input:{projectId:$project,itemId:$item,fieldId:$field,value:{singleSelectOptionId:$option}}) { projectV2Item { id } } }'
+  gh api graphql -f query="$query" -f project="$PROJECT_ID" -f item="$ITEM_ID" -f field="$field_id" -f option="$option_id" >/dev/null
+}
+
+update_text() {
+  local field_id="$1"
+  local text="$2"
+  local label="$3"
+  if [[ -z "$field_id" ]]; then
+    echo "::warning::Skipping ${label}; missing field id"
+    return 0
+  fi
+  local query='mutation($project:ID!, $item:ID!, $field:ID!, $text:String!) { updateProjectV2ItemFieldValue(input:{projectId:$project,itemId:$item,fieldId:$field,value:{text:$text}}) { projectV2Item { id } } }'
+  gh api graphql -f query="$query" -f project="$PROJECT_ID" -f item="$ITEM_ID" -f field="$field_id" -f text="$text" >/dev/null
+}
+
+WAVE_FIELD_ID="$(get_field_id 'Wave')"
+TIER_FIELD_ID="$(get_field_id 'Tier')"
+NODE_FIELD_ID="$(get_field_id 'Node')"
+ADR_FIELD_ID="$(get_field_id 'ADR')"
+INITIATIVE_FIELD_ID="$(get_field_id 'Initiative')"
+
+WAVE_TARGET='N/A'
+case "$WAVE_LABEL" in
+  wave-1) WAVE_TARGET='Wave 1' ;;
+  wave-2) WAVE_TARGET='Wave 2' ;;
+  wave-3) WAVE_TARGET='Wave 3' ;;
+esac
+WAVE_OPTION_ID="$(get_single_option_id 'Wave' "$WAVE_TARGET")"
+update_single_select "$WAVE_FIELD_ID" "$WAVE_OPTION_ID" 'Wave'
+
+if [[ -n "$TIER_LABEL" ]]; then
+  TIER_TARGET="Tier ${TIER_LABEL#tier-}"
+  TIER_OPTION_ID="$(get_single_option_id 'Tier' "$TIER_TARGET")"
+  if [[ -z "$TIER_OPTION_ID" ]]; then
+    TIER_OPTION_ID="$(get_single_option_id 'Tier' "${TIER_LABEL#tier-}")"
+  fi
+  update_single_select "$TIER_FIELD_ID" "$TIER_OPTION_ID" 'Tier'
+fi
+
+if [[ -n "$NODE_OPTION" ]]; then
+  NODE_OPTION_ID="$(get_single_option_id 'Node' "$NODE_OPTION")"
+  update_single_select "$NODE_FIELD_ID" "$NODE_OPTION_ID" 'Node'
+else
+  echo "::warning::No node mapping found for repository ${ISSUE_REPO}"
+fi
+
+if [[ -n "$INITIATIVE_SLUG" ]]; then
+  INITIATIVE_OPTION_ID="$(get_single_option_id 'Initiative' "$INITIATIVE_SLUG")"
+  if [[ -z "$INITIATIVE_OPTION_ID" ]]; then
+    INITIATIVE_OPTION_ID="$(get_single_option_id 'Initiative' "Initiative ${INITIATIVE_SLUG}")"
+  fi
+  if [[ -n "$INITIATIVE_OPTION_ID" ]]; then
+    update_single_select "$INITIATIVE_FIELD_ID" "$INITIATIVE_OPTION_ID" 'Initiative'
+  else
+    echo "::warning::No Initiative option matched label initiative-${INITIATIVE_SLUG}"
+  fi
+fi
+
+update_text "$ADR_FIELD_ID" "$ADR_TEXT" 'ADR'
+
+echo "Mirrored fields for ${ISSUE_OWNER}/${ISSUE_REPO}#${ISSUE_NUMBER}"

--- a/scripts/hive-project-mirror.sh
+++ b/scripts/hive-project-mirror.sh
@@ -205,6 +205,8 @@ if [[ -n "$INITIATIVE_SLUG" ]]; then
   fi
 fi
 
-update_text "$ADR_FIELD_ID" "$ADR_TEXT" 'ADR'
+if [[ -n "$ADR_TEXT" ]]; then
+  update_text "$ADR_FIELD_ID" "$ADR_TEXT" 'ADR'
+fi
 
 echo "Mirrored fields for ${ISSUE_OWNER}/${ISSUE_REPO}#${ISSUE_NUMBER}"

--- a/scripts/hive-project-mirror.sh
+++ b/scripts/hive-project-mirror.sh
@@ -62,7 +62,7 @@ if ! command -v gh >/dev/null 2>&1; then
 fi
 
 if ! command -v python3 >/dev/null 2>&1; then
-  echo "python3 is required" >&2
+  echo "python3 is required for repo-to-node mapping lookup" >&2
   exit 1
 fi
 

--- a/scripts/hive-project-mirror.sh
+++ b/scripts/hive-project-mirror.sh
@@ -61,6 +61,11 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required" >&2
+  exit 1
+fi
+
 ISSUE_JSON="$(gh api "repos/${ISSUE_OWNER}/${ISSUE_REPO}/issues/${ISSUE_NUMBER}")"
 ISSUE_NODE_ID="$(jq -r '.node_id' <<<"$ISSUE_JSON")"
 if [[ -z "$ISSUE_NODE_ID" || "$ISSUE_NODE_ID" == "null" ]]; then
@@ -75,7 +80,7 @@ TIER_LABEL=""
 INITIATIVE_SLUG=""
 ADR_LABELS=()
 
-for label in "${LABELS[@]:-}"; do
+for label in "${LABELS[@]}"; do
   case "$label" in
     wave-1|wave-2|wave-3) WAVE_LABEL="$label" ;;
     tier-1|tier-2|tier-3) TIER_LABEL="$label" ;;

--- a/scripts/hive-project-mirror.sh
+++ b/scripts/hive-project-mirror.sh
@@ -136,20 +136,9 @@ else
 fi
 
 if [[ -z "$ITEM_ID" ]]; then
-  lookup_query='query($project: ID!, $after: String) { node(id: $project) { ... on ProjectV2 { items(first: 100, after: $after) { nodes { id content { ... on Issue { id } } } pageInfo { hasNextPage endCursor } } } } }'
-  HAS_NEXT_PAGE="true"
-  END_CURSOR=""
-  while [[ "$HAS_NEXT_PAGE" == "true" && -z "$ITEM_ID" ]]; do
-    if [[ -n "$END_CURSOR" ]]; then
-      LOOKUP_JSON="$(gh api graphql -f query="$lookup_query" -f project="$PROJECT_ID" -f after="$END_CURSOR")"
-    else
-      LOOKUP_JSON="$(gh api graphql -f query="$lookup_query" -f project="$PROJECT_ID")"
-    fi
-
-    ITEM_ID="$(jq -r --arg issue_id "$ISSUE_NODE_ID" '.data.node.items.nodes[] | select(.content.id == $issue_id) | .id' <<<"$LOOKUP_JSON" | head -n1)"
-    HAS_NEXT_PAGE="$(jq -r '.data.node.items.pageInfo.hasNextPage' <<<"$LOOKUP_JSON")"
-    END_CURSOR="$(jq -r '.data.node.items.pageInfo.endCursor // empty' <<<"$LOOKUP_JSON")"
-  done
+  lookup_query='query($issue: ID!) { node(id: $issue) { ... on Issue { projectItems(first: 100) { nodes { id project { id } } } } } }'
+  LOOKUP_JSON="$(gh api graphql -f query="$lookup_query" -f issue="$ISSUE_NODE_ID")"
+  ITEM_ID="$(jq -r --arg project_id "$PROJECT_ID" '.data.node.projectItems.nodes[] | select(.project.id == $project_id) | .id' <<<"$LOOKUP_JSON" | head -n1)"
 fi
 
 if [[ -z "$ITEM_ID" ]]; then


### PR DESCRIPTION
### Motivation
- Close ADR-0008 §D4 gap by automating mirroring of well-known issue labels and the source repository into The Hive (org Project v2 #4) so board custom fields are not left blank after issue creation.
- Avoid manual CLI backfills for every new issue filed across the organization by providing an idempotent, reusable automation that runs on `issues.*` events or via `workflow_call`.
- Preserve human ownership of `Status` and be resilient to missing project options by discovering field/option IDs at runtime and emitting warnings rather than failing.

### Description
- Add reusable workflow `.github/workflows/hive-field-mirror.yml` that triggers on `issues` events and supports `workflow_call`, consumes `HIVE_FIELD_MIRROR_TOKEN` (or `hive-field-mirror-token` input), and resolves the target issue URL for the mirror step.
- Add repository-to-node lookup `.github/config/repo-to-node.yml` containing the requested HoneyDrunk repo → node mappings used to populate the `Node` single-select field.
- Add `scripts/hive-project-mirror.sh` which is the idempotent implementation that: loads issue labels via `gh api`, uses `addProjectV2ItemById`, discovers project field and option IDs at runtime via `gh project field-list`, maps and updates `Wave`, `Tier`, `Node`, `ADR` (text), and optional `Initiative`, and never writes `Status`.
- Add `scripts/hive-backfill-issue.sh` as a thin wrapper for one-off backfills by issue URL and update `README.md` with usage, mapping rules, per-repo enablement snippet, and token rotation guidance.

### Testing
- Automated shell syntax validation `bash -n scripts/hive-project-mirror.sh scripts/hive-backfill-issue.sh` completed successfully (scripts are syntactically valid).
- `actionlint .github/workflows/hive-field-mirror.yml` was attempted but could not be run in this environment because `actionlint` is not installed (command not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daad040d888326a3398bf7e623a6b0)