### PR TITLE
ci(release): create artifacts directory before SBOM step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,6 +307,10 @@ jobs:
           project-path: ${{ inputs.project-path }}
           fail-on-severity: 'moderate'  # Stricter for releases
       
+      - name: Create artifacts directory
+        shell: bash
+        run: mkdir -p ${{ inputs.working-directory }}/artifacts
+
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,7 +309,7 @@ jobs:
       
       - name: Create artifacts directory
         shell: bash
-        run: mkdir -p ${{ inputs.working-directory }}/artifacts
+        run: mkdir -p "${{ inputs.working-directory }}/artifacts"
 
       - name: Generate SBOM
         uses: anchore/sbom-action@v0


### PR DESCRIPTION
Add step to ensure artifacts directory exists in release workflow prior to generating SBOM, improving reliability of artifact handling