### PR TITLE
chore(ci): add github_token to agent run step for access

### DIFF
--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -169,6 +169,7 @@ jobs:
         with:
           prompt: ${{ steps.resolve.outputs.prompt }}
           anthropic_api_key: ${{ secrets.anthropic-api-key }}
+          github_token: ${{ secrets.github-token }}
           claude_args: |
             --allowedTools ${{ inputs.allowed-tools }}
             --max-turns ${{ inputs.max-turns }}


### PR DESCRIPTION
Ensure agent has access to GitHub token by passing github_token env variable in agent-run.yml