### PR TITLE
ci(gitleaks): use linux_x64 tarball naming in pipelines

### DIFF
--- a/.github/workflows/job-secret-scan.yml
+++ b/.github/workflows/job-secret-scan.yml
@@ -90,7 +90,7 @@ jobs:
             VERSION="$GITLEAKS_VERSION"
           fi
 
-          TARBALL="gitleaks_${VERSION#v}_linux_amd64.tar.gz"
+          TARBALL="gitleaks_${VERSION#v}_linux_x64.tar.gz"
           BASE_URL="https://github.com/gitleaks/gitleaks/releases/download/${VERSION}"
 
           curl -sSfL "${BASE_URL}/${TARBALL}" -o "/tmp/${TARBALL}"

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -281,7 +281,7 @@ jobs:
         run: |
           set -euo pipefail
           GITLEAKS_VERSION="8.21.2"
-          GITLEAKS_TARBALL="gitleaks_${GITLEAKS_VERSION}_linux_amd64.tar.gz"
+          GITLEAKS_TARBALL="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
           GITLEAKS_BASE_URL="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
 
           curl -sSfL "${GITLEAKS_BASE_URL}/${GITLEAKS_TARBALL}" -o "/tmp/${GITLEAKS_TARBALL}"


### PR DESCRIPTION
Update Gitleaks download tarball from linux_amd64 to linux_x64 in CI workflows to match upstream artifact naming