### PR TITLE
feat(ci): add reusable dependency scan and CodeQL jobs for PRs

### DIFF
--- a/.github/workflows/job-codeql.yml
+++ b/.github/workflows/job-codeql.yml
@@ -1,0 +1,284 @@
+# ==============================================================================
+# CodeQL SAST Job
+# ==============================================================================
+# Purpose:
+#   Run CodeQL static analysis on every pull request using the
+#   `security-and-quality` query pack — the same suite the nightly workflow
+#   uses. Uploads SARIF to GitHub Code Scanning and fails the PR when findings
+#   at or above the configured SARIF severity are present.
+#
+# Single Responsibility:
+#   CodeQL analysis only (C# today; extend the `languages` input for more).
+#
+# Non-goals:
+#   Dependency vulnerability scanning (see job-dependency-scan.yml), secret
+#   scanning (see job-secret-scan.yml), IaC scanning (nightly-security.yml).
+# ==============================================================================
+
+name: CodeQL (Job)
+
+on:
+  workflow_call:
+    inputs:
+      dotnet-version:
+        description: 'The .NET SDK version to use'
+        required: false
+        type: string
+        default: '10.0.x'
+
+      runs-on:
+        description: 'GitHub runner to use'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+
+      working-directory:
+        description: 'Working directory for build'
+        required: false
+        type: string
+        default: '.'
+
+      project-path:
+        description: 'Path to solution or project file (auto-detected if not specified)'
+        required: false
+        type: string
+        default: ''
+
+      languages:
+        description: 'CodeQL languages to analyze (comma-separated)'
+        required: false
+        type: string
+        default: 'csharp'
+
+      queries:
+        description: 'CodeQL query suite to run (security-and-quality, security-extended, security)'
+        required: false
+        type: string
+        default: 'security-and-quality'
+
+      category:
+        description: 'Code Scanning category used to separate PR findings from nightly'
+        required: false
+        type: string
+        default: 'pr-sast'
+
+      fail-on-severity:
+        description: 'Lowest SARIF severity that fails the PR (error, warning, note, none)'
+        required: false
+        type: string
+        default: 'note'
+
+      actions-ref:
+        description: 'Git ref of HoneyDrunk.Actions to use'
+        required: false
+        type: string
+        default: 'main'
+
+    outputs:
+      has-warnings:
+        description: 'Whether any CodeQL findings were reported'
+        value: ${{ jobs.codeql.outputs.has-warnings }}
+      warning-messages:
+        description: 'Human-readable summary of findings'
+        value: ${{ jobs.codeql.outputs.warning-messages }}
+      findings-count:
+        description: 'Total number of CodeQL findings'
+        value: ${{ jobs.codeql.outputs.findings-count }}
+      error-count:
+        description: 'Findings with SARIF severity error'
+        value: ${{ jobs.codeql.outputs.error-count }}
+      warning-count:
+        description: 'Findings with SARIF severity warning'
+        value: ${{ jobs.codeql.outputs.warning-count }}
+      note-count:
+        description: 'Findings with SARIF severity note'
+        value: ${{ jobs.codeql.outputs.note-count }}
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  codeql:
+    name: CodeQL
+    runs-on: ${{ inputs.runs-on }}
+    outputs:
+      has-warnings: ${{ steps.evaluate.outputs.has-warnings }}
+      warning-messages: ${{ steps.evaluate.outputs.warning-messages }}
+      findings-count: ${{ steps.evaluate.outputs.findings-count }}
+      error-count: ${{ steps.evaluate.outputs.error-count }}
+      warning-count: ${{ steps.evaluate.outputs.warning-count }}
+      note-count: ${{ steps.evaluate.outputs.note-count }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Detect repo-local CodeQL config
+        id: codeql-config
+        shell: bash
+        run: |
+          if [ -f "./.github/codeql/codeql-config.yml" ]; then
+            echo "path=./.github/codeql/codeql-config.yml" >> $GITHUB_OUTPUT
+          elif [ -f "./.github/codeql/codeql-config.yaml" ]; then
+            echo "path=./.github/codeql/codeql-config.yaml" >> $GITHUB_OUTPUT
+          else
+            echo "path=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ inputs.languages }}
+          queries: ${{ inputs.queries }}
+          config-file: ${{ steps.codeql-config.outputs.path }}
+
+      - name: Checkout HoneyDrunk.Actions
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          path: .github/actions-repo
+          ref: ${{ inputs.actions-ref }}
+
+      - name: Setup .NET SDK
+        uses: ./.github/actions-repo/.github/actions/dotnet/setup
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+
+      - name: Build for CodeQL analysis
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          set -euo pipefail
+
+          PROJECT="${{ inputs.project-path }}"
+          if [ -z "$PROJECT" ]; then
+            PROJECT=$(find . -maxdepth 4 \( -name '*.slnx' -o -name '*.sln' \) | head -n 1 || true)
+          fi
+
+          if [ -z "$PROJECT" ]; then
+            echo "::error::No solution or project found for CodeQL build."
+            exit 1
+          fi
+
+          echo "Building $PROJECT for CodeQL..."
+          dotnet build "$PROJECT" --no-incremental
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: ${{ inputs.category }}
+          output: ${{ inputs.working-directory }}/codeql-results
+          upload: true
+
+      - name: Evaluate findings
+        id: evaluate
+        if: always()
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          FAIL_ON_SEVERITY: ${{ inputs.fail-on-severity }}
+        run: |
+          set -euo pipefail
+
+          RESULTS_DIR=./codeql-results
+          if [ ! -d "$RESULTS_DIR" ]; then
+            echo "has-warnings=false" >> "$GITHUB_OUTPUT"
+            echo "warning-messages=" >> "$GITHUB_OUTPUT"
+            echo "findings-count=0" >> "$GITHUB_OUTPUT"
+            echo "error-count=0" >> "$GITHUB_OUTPUT"
+            echo "warning-count=0" >> "$GITHUB_OUTPUT"
+            echo "note-count=0" >> "$GITHUB_OUTPUT"
+            echo "::warning::CodeQL produced no SARIF directory; treating as no findings."
+            exit 0
+          fi
+
+          COUNTS=$(python3 - "$RESULTS_DIR" <<'PY'
+          import json, pathlib, sys
+          from collections import Counter
+
+          root = pathlib.Path(sys.argv[1])
+          counts = Counter()
+          total = 0
+
+          for sarif_path in root.rglob("*.sarif"):
+              try:
+                  data = json.loads(sarif_path.read_text())
+              except Exception:
+                  continue
+              for run in data.get("runs", []):
+                  # Build a rule id -> default severity map so we can fall back
+                  # when a result omits its level (CodeQL usually emits it).
+                  rule_levels = {}
+                  tool = run.get("tool", {}).get("driver", {})
+                  for rule in tool.get("rules", []) or []:
+                      rid = rule.get("id")
+                      level = (rule.get("defaultConfiguration") or {}).get("level")
+                      if rid and level:
+                          rule_levels[rid] = level
+
+                  for result in run.get("results", []):
+                      level = result.get("level")
+                      if not level:
+                          level = rule_levels.get(result.get("ruleId"), "warning")
+                      counts[level] += 1
+                      total += 1
+
+          print(f"TOTAL={total}")
+          for sev in ("error", "warning", "note"):
+              print(f"{sev.upper()}={counts[sev]}")
+          PY
+          )
+
+          eval "$COUNTS"
+
+          echo "findings-count=${TOTAL}" >> "$GITHUB_OUTPUT"
+          echo "error-count=${ERROR}"   >> "$GITHUB_OUTPUT"
+          echo "warning-count=${WARNING}" >> "$GITHUB_OUTPUT"
+          echo "note-count=${NOTE}"     >> "$GITHUB_OUTPUT"
+
+          if [ "${TOTAL}" -eq 0 ]; then
+            echo "has-warnings=false" >> "$GITHUB_OUTPUT"
+            echo "warning-messages=" >> "$GITHUB_OUTPUT"
+            echo "✅ No CodeQL findings."
+            exit 0
+          fi
+
+          PARTS=()
+          [ "${ERROR}"   -gt 0 ] && PARTS+=("${ERROR} error")
+          [ "${WARNING}" -gt 0 ] && PARTS+=("${WARNING} warning")
+          [ "${NOTE}"    -gt 0 ] && PARTS+=("${NOTE} note")
+          BREAKDOWN=$(IFS=', '; echo "${PARTS[*]}")
+
+          MSG="CodeQL found ${TOTAL} finding(s): ${BREAKDOWN}. See Code Scanning alerts (category '${{ inputs.category }}') or the sast-report artifact for detail."
+          echo "has-warnings=true"       >> "$GITHUB_OUTPUT"
+          echo "warning-messages=${MSG}" >> "$GITHUB_OUTPUT"
+          echo "::warning::${MSG}"
+
+          case "${FAIL_ON_SEVERITY}" in
+            none)
+              GATE=0 ;;
+            note)
+              GATE=${TOTAL} ;;
+            warning)
+              GATE=$((ERROR + WARNING)) ;;
+            error)
+              GATE=${ERROR} ;;
+            *)
+              echo "::error::Unknown fail-on-severity '${FAIL_ON_SEVERITY}'"
+              exit 1 ;;
+          esac
+
+          if [ "${GATE}" -gt 0 ]; then
+            echo "::error::Failing PR — ${GATE} CodeQL finding(s) at or above '${FAIL_ON_SEVERITY}' severity."
+            exit 1
+          fi
+
+      - name: Upload SARIF artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sast-report
+          path: ${{ inputs.working-directory }}/codeql-results/**/*.sarif
+          retention-days: 90
+          if-no-files-found: ignore

--- a/.github/workflows/job-dependency-scan.yml
+++ b/.github/workflows/job-dependency-scan.yml
@@ -59,13 +59,13 @@ on:
 
     outputs:
       has-warnings:
-        description: 'Whether any vulnerable packages were found (regardless of severity gate)'
+        description: 'Whether any vulnerabilities were found (regardless of severity gate)'
         value: ${{ jobs.dependency-scan.outputs.has-warnings }}
       warning-messages:
         description: 'Human-readable summary of findings'
         value: ${{ jobs.dependency-scan.outputs.warning-messages }}
       findings-count:
-        description: 'Total number of vulnerable packages (direct + transitive)'
+        description: 'Total number of vulnerabilities found across direct + transitive packages'
         value: ${{ jobs.dependency-scan.outputs.findings-count }}
       critical-count:
         description: 'Number of critical-severity vulnerabilities'
@@ -127,7 +127,10 @@ jobs:
 
           TARGET="${{ inputs.project-path }}"
           if [ -z "$TARGET" ]; then
-            TARGET=$(find . -maxdepth 4 \( -name '*.slnx' -o -name '*.sln' \) | head -n 1 || true)
+            TARGET=$(find . -maxdepth 4 \( -name '*.slnx' -o -name '*.sln' \) | sort | head -n 1 || true)
+          fi
+          if [ -z "$TARGET" ]; then
+            TARGET=$(find . -maxdepth 4 \( -name '*.csproj' -o -name '*.fsproj' -o -name '*.vbproj' \) | sort | head -n 1 || true)
           fi
 
           if [ -z "$TARGET" ]; then
@@ -138,27 +141,33 @@ jobs:
           fi
 
           mkdir -p ./security-reports
+          JSON_REPORT=./security-reports/vulnerable-packages.json
+          ERROR_REPORT=./security-reports/vulnerable-packages.err
 
-          # --format json was added in .NET SDK 9. Projects on SDK 9+ get a
-          # structured report; older SDKs will error out on --format, so we
-          # fall back to the text format and let the evaluator handle it.
+          # JSON output is required by downstream evaluation. If the scan fails
+          # or does not produce JSON, fail the job so we do not report a false
+          # clean result. Requires .NET SDK 9+ (default 10.0.x).
           SCAN_ARGS=(package --vulnerable --include-transitive --format json)
 
+          set +e
           if [ -n "$TARGET" ]; then
-            dotnet list "$TARGET" "${SCAN_ARGS[@]}" \
-              > ./security-reports/vulnerable-packages.json \
-              2> ./security-reports/vulnerable-packages.err || true
+            dotnet list "$TARGET" "${SCAN_ARGS[@]}" > "$JSON_REPORT" 2> "$ERROR_REPORT"
           else
-            dotnet list "${SCAN_ARGS[@]}" \
-              > ./security-reports/vulnerable-packages.json \
-              2> ./security-reports/vulnerable-packages.err || true
+            dotnet list "${SCAN_ARGS[@]}" > "$JSON_REPORT" 2> "$ERROR_REPORT"
+          fi
+          SCAN_EXIT_CODE=$?
+          set -e
+
+          if [ "$SCAN_EXIT_CODE" -ne 0 ]; then
+            echo "::error::dotnet list package scan failed with exit code $SCAN_EXIT_CODE."
+            cat "$ERROR_REPORT" || true
+            exit "$SCAN_EXIT_CODE"
           fi
 
-          if [ ! -s ./security-reports/vulnerable-packages.json ]; then
-            echo "::warning::dotnet list did not produce JSON output; see error log artifact."
-            cat ./security-reports/vulnerable-packages.err || true
-            # Write an empty-results JSON so downstream steps have a consistent input.
-            echo '{"projects":[]}' > ./security-reports/vulnerable-packages.json
+          if [ ! -s "$JSON_REPORT" ]; then
+            echo "::error::dotnet list completed without producing JSON output."
+            cat "$ERROR_REPORT" || true
+            exit 1
           fi
 
       - name: Evaluate findings
@@ -221,7 +230,7 @@ jobs:
           if [ "${TOTAL}" -eq 0 ]; then
             echo "has-warnings=false" >> "$GITHUB_OUTPUT"
             echo "warning-messages=" >> "$GITHUB_OUTPUT"
-            echo "✅ No vulnerable packages found."
+            echo "✅ No vulnerabilities found."
             exit 0
           fi
 
@@ -234,7 +243,7 @@ jobs:
           [ "${UNKNOWN}"  -gt 0 ] && PARTS+=("${UNKNOWN} unknown")
           BREAKDOWN=$(IFS=', '; echo "${PARTS[*]}")
 
-          MSG="Found ${TOTAL} vulnerable package(s): ${BREAKDOWN}. See vulnerable-packages artifact for detail."
+          MSG="Found ${TOTAL} vulnerabilities: ${BREAKDOWN}. See vulnerable-packages artifact for detail."
           echo "has-warnings=true"              >> "$GITHUB_OUTPUT"
           echo "warning-messages=${MSG}"        >> "$GITHUB_OUTPUT"
           echo "::warning::${MSG}"

--- a/.github/workflows/job-dependency-scan.yml
+++ b/.github/workflows/job-dependency-scan.yml
@@ -1,0 +1,271 @@
+# ==============================================================================
+# Dependency Vulnerability Scan Job
+# ==============================================================================
+# Purpose:
+#   Scan a .NET project/solution for vulnerable NuGet packages (direct and
+#   transitive) on every pull request. Emits a severity breakdown so the PR
+#   summary can surface findings; fails the job if any vulnerability at or
+#   above `fail-on-severity` is found.
+#
+# Single Responsibility:
+#   Vulnerable-package detection only. Uses `dotnet list package --vulnerable
+#   --include-transitive --format json`.
+#
+# Non-goals:
+#   Deep SAST, IaC, or secret scanning (those have dedicated jobs / nightly
+#   workflow).
+# ==============================================================================
+
+name: Dependency Scan (Job)
+
+on:
+  workflow_call:
+    inputs:
+      dotnet-version:
+        description: 'The .NET SDK version to use'
+        required: false
+        type: string
+        default: '10.0.x'
+
+      runs-on:
+        description: 'GitHub runner to use'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+
+      working-directory:
+        description: 'Working directory for all operations'
+        required: false
+        type: string
+        default: '.'
+
+      project-path:
+        description: 'Path to solution or project file (auto-detected if not specified)'
+        required: false
+        type: string
+        default: ''
+
+      fail-on-severity:
+        description: 'Minimum severity that fails the job (critical, high, moderate, low, none)'
+        required: false
+        type: string
+        default: 'high'
+
+      actions-ref:
+        description: 'Git ref of HoneyDrunk.Actions to use'
+        required: false
+        type: string
+        default: 'main'
+
+    outputs:
+      has-warnings:
+        description: 'Whether any vulnerable packages were found (regardless of severity gate)'
+        value: ${{ jobs.dependency-scan.outputs.has-warnings }}
+      warning-messages:
+        description: 'Human-readable summary of findings'
+        value: ${{ jobs.dependency-scan.outputs.warning-messages }}
+      findings-count:
+        description: 'Total number of vulnerable packages (direct + transitive)'
+        value: ${{ jobs.dependency-scan.outputs.findings-count }}
+      critical-count:
+        description: 'Number of critical-severity vulnerabilities'
+        value: ${{ jobs.dependency-scan.outputs.critical-count }}
+      high-count:
+        description: 'Number of high-severity vulnerabilities'
+        value: ${{ jobs.dependency-scan.outputs.high-count }}
+      moderate-count:
+        description: 'Number of moderate-severity vulnerabilities'
+        value: ${{ jobs.dependency-scan.outputs.moderate-count }}
+      low-count:
+        description: 'Number of low-severity vulnerabilities'
+        value: ${{ jobs.dependency-scan.outputs.low-count }}
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-scan:
+    name: Dependency Scan
+    runs-on: ${{ inputs.runs-on }}
+    outputs:
+      has-warnings: ${{ steps.evaluate.outputs.has-warnings }}
+      warning-messages: ${{ steps.evaluate.outputs.warning-messages }}
+      findings-count: ${{ steps.evaluate.outputs.findings-count }}
+      critical-count: ${{ steps.evaluate.outputs.critical-count }}
+      high-count: ${{ steps.evaluate.outputs.high-count }}
+      moderate-count: ${{ steps.evaluate.outputs.moderate-count }}
+      low-count: ${{ steps.evaluate.outputs.low-count }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout HoneyDrunk.Actions
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          path: .github/actions-repo
+          ref: ${{ inputs.actions-ref }}
+
+      - name: Setup .NET SDK
+        uses: ./.github/actions-repo/.github/actions/dotnet/setup
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+
+      - name: Restore dependencies
+        uses: ./.github/actions-repo/.github/actions/dotnet/restore
+        with:
+          working-directory: ${{ inputs.working-directory }}
+          project-path: ${{ inputs.project-path }}
+
+      - name: Scan for vulnerable packages
+        id: scan
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          set -euo pipefail
+
+          TARGET="${{ inputs.project-path }}"
+          if [ -z "$TARGET" ]; then
+            TARGET=$(find . -maxdepth 4 \( -name '*.slnx' -o -name '*.sln' \) | head -n 1 || true)
+          fi
+
+          if [ -z "$TARGET" ]; then
+            echo "::warning::No solution or project found; scanning via working directory."
+            TARGET=""
+          else
+            echo "Scanning $TARGET for vulnerable packages..."
+          fi
+
+          mkdir -p ./security-reports
+
+          # --format json was added in .NET SDK 9. Projects on SDK 9+ get a
+          # structured report; older SDKs will error out on --format, so we
+          # fall back to the text format and let the evaluator handle it.
+          SCAN_ARGS=(package --vulnerable --include-transitive --format json)
+
+          if [ -n "$TARGET" ]; then
+            dotnet list "$TARGET" "${SCAN_ARGS[@]}" \
+              > ./security-reports/vulnerable-packages.json \
+              2> ./security-reports/vulnerable-packages.err || true
+          else
+            dotnet list "${SCAN_ARGS[@]}" \
+              > ./security-reports/vulnerable-packages.json \
+              2> ./security-reports/vulnerable-packages.err || true
+          fi
+
+          if [ ! -s ./security-reports/vulnerable-packages.json ]; then
+            echo "::warning::dotnet list did not produce JSON output; see error log artifact."
+            cat ./security-reports/vulnerable-packages.err || true
+            # Write an empty-results JSON so downstream steps have a consistent input.
+            echo '{"projects":[]}' > ./security-reports/vulnerable-packages.json
+          fi
+
+      - name: Evaluate findings
+        id: evaluate
+        if: always()
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          FAIL_ON_SEVERITY: ${{ inputs.fail-on-severity }}
+        run: |
+          set -euo pipefail
+
+          REPORT=./security-reports/vulnerable-packages.json
+          if [ ! -f "$REPORT" ]; then
+            echo "has-warnings=false" >> "$GITHUB_OUTPUT"
+            echo "warning-messages=" >> "$GITHUB_OUTPUT"
+            echo "findings-count=0" >> "$GITHUB_OUTPUT"
+            echo "critical-count=0" >> "$GITHUB_OUTPUT"
+            echo "high-count=0" >> "$GITHUB_OUTPUT"
+            echo "moderate-count=0" >> "$GITHUB_OUTPUT"
+            echo "low-count=0" >> "$GITHUB_OUTPUT"
+            echo "No report produced; treating as no findings."
+            exit 0
+          fi
+
+          # Flatten top-level + transitive packages across all projects/frameworks
+          # and tally vulnerabilities by severity (normalized to lowercase).
+          COUNTS=$(python3 - "$REPORT" <<'PY'
+          import json, sys
+          from collections import Counter
+
+          with open(sys.argv[1]) as f:
+              data = json.load(f)
+
+          counts = Counter()
+          total = 0
+          for project in data.get("projects", []):
+              for framework in project.get("frameworks", []):
+                  for bucket in ("topLevelPackages", "transitivePackages"):
+                      for pkg in framework.get(bucket, []) or []:
+                          for vuln in pkg.get("vulnerabilities", []) or []:
+                              severity = (vuln.get("severity") or "unknown").lower()
+                              counts[severity] += 1
+                              total += 1
+
+          print(f"TOTAL={total}")
+          for sev in ("critical", "high", "moderate", "low", "unknown"):
+              print(f"{sev.upper()}={counts[sev]}")
+          PY
+          )
+
+          eval "$COUNTS"
+
+          echo "findings-count=${TOTAL}"       >> "$GITHUB_OUTPUT"
+          echo "critical-count=${CRITICAL}"    >> "$GITHUB_OUTPUT"
+          echo "high-count=${HIGH}"            >> "$GITHUB_OUTPUT"
+          echo "moderate-count=${MODERATE}"    >> "$GITHUB_OUTPUT"
+          echo "low-count=${LOW}"              >> "$GITHUB_OUTPUT"
+
+          if [ "${TOTAL}" -eq 0 ]; then
+            echo "has-warnings=false" >> "$GITHUB_OUTPUT"
+            echo "warning-messages=" >> "$GITHUB_OUTPUT"
+            echo "✅ No vulnerable packages found."
+            exit 0
+          fi
+
+          # Build breakdown string like "1 critical, 2 high, 3 moderate"
+          PARTS=()
+          [ "${CRITICAL}" -gt 0 ] && PARTS+=("${CRITICAL} critical")
+          [ "${HIGH}"     -gt 0 ] && PARTS+=("${HIGH} high")
+          [ "${MODERATE}" -gt 0 ] && PARTS+=("${MODERATE} moderate")
+          [ "${LOW}"      -gt 0 ] && PARTS+=("${LOW} low")
+          [ "${UNKNOWN}"  -gt 0 ] && PARTS+=("${UNKNOWN} unknown")
+          BREAKDOWN=$(IFS=', '; echo "${PARTS[*]}")
+
+          MSG="Found ${TOTAL} vulnerable package(s): ${BREAKDOWN}. See vulnerable-packages artifact for detail."
+          echo "has-warnings=true"              >> "$GITHUB_OUTPUT"
+          echo "warning-messages=${MSG}"        >> "$GITHUB_OUTPUT"
+          echo "::warning::${MSG}"
+
+          # Apply fail-on-severity gate.
+          case "${FAIL_ON_SEVERITY}" in
+            none)
+              GATE=0 ;;
+            low)
+              GATE=$((CRITICAL + HIGH + MODERATE + LOW)) ;;
+            moderate)
+              GATE=$((CRITICAL + HIGH + MODERATE)) ;;
+            high)
+              GATE=$((CRITICAL + HIGH)) ;;
+            critical)
+              GATE=${CRITICAL} ;;
+            *)
+              echo "::error::Unknown fail-on-severity '${FAIL_ON_SEVERITY}'"
+              exit 1 ;;
+          esac
+
+          if [ "${GATE}" -gt 0 ]; then
+            echo "::error::Failing PR — ${GATE} finding(s) at or above '${FAIL_ON_SEVERITY}' severity."
+            exit 1
+          fi
+
+      - name: Upload vulnerability report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vulnerable-packages
+          path: ${{ inputs.working-directory }}/security-reports/**/*
+          retention-days: 90
+          if-no-files-found: ignore

--- a/.github/workflows/job-static-analysis.yml
+++ b/.github/workflows/job-static-analysis.yml
@@ -2,8 +2,8 @@
 # Static Analysis Job
 # ==============================================================================
 # Purpose:
-#   Run static analysis checks including code formatting, vulnerability scanning,
-#   and test naming validation.
+#   Run static analysis checks: code formatting and test naming validation.
+#   Vulnerable-package scanning lives in job-dependency-scan.yml.
 #
 # Single Responsibility:
 #   Static code analysis only - no building or testing
@@ -49,12 +49,6 @@ on:
         required: false
         type: boolean
         default: false
-      
-      fail-on-severity:
-        description: 'Minimum vulnerability severity to fail (low, moderate, high, critical)'
-        required: false
-        type: string
-        default: 'high'
       
       validate-test-naming:
         description: 'Validate test naming conventions'
@@ -129,13 +123,6 @@ jobs:
           else
             echo "has-issue=false" >> $GITHUB_OUTPUT
           fi
-      
-      - name: Run vulnerability scan
-        uses: ./.github/actions-repo/.github/actions/security/vulnerability-scan
-        with:
-          working-directory: ${{ inputs.working-directory }}
-          project-path: ${{ inputs.project-path }}
-          fail-on-severity: ${{ inputs.fail-on-severity }}
       
       - name: Validate test naming conventions
         if: ${{ inputs.validate-test-naming }}

--- a/.github/workflows/pr-core.yml
+++ b/.github/workflows/pr-core.yml
@@ -66,7 +66,37 @@ on:
         required: false
         type: boolean
         default: true
-      
+
+      enable-dependency-scan:
+        description: 'Run vulnerable-package scan (dotnet list --vulnerable)'
+        required: false
+        type: boolean
+        default: true
+
+      dependency-fail-on-severity:
+        description: 'Minimum vulnerability severity that fails the PR (critical, high, moderate, low, none)'
+        required: false
+        type: string
+        default: 'high'
+
+      enable-codeql:
+        description: 'Run CodeQL SAST / code-quality scan on the PR'
+        required: false
+        type: boolean
+        default: true
+
+      codeql-queries:
+        description: 'CodeQL query suite to run (security-and-quality, security-extended, security)'
+        required: false
+        type: string
+        default: 'security-and-quality'
+
+      codeql-fail-on-severity:
+        description: 'Lowest SARIF severity that fails the PR (error, warning, note, none)'
+        required: false
+        type: string
+        default: 'note'
+
       enable-accessibility-check:
         description: 'Run minimal accessibility check (opt-in)'
         required: false
@@ -130,7 +160,6 @@ jobs:
       project-path: ${{ inputs.project-path }}
       check-formatting: true
       fail-on-formatting-issues: false  # Warn only in PR
-      fail-on-severity: 'high'
       validate-test-naming: true
       actions-ref: ${{ inputs.actions-ref }}
     permissions:
@@ -145,7 +174,39 @@ jobs:
       runs-on: ${{ inputs.runs-on }}
       scan-mode: 'diff-only'
 
-  # Job 4: Accessibility Check (Optional)
+  # Job 4: Dependency Vulnerability Scan (Optional)
+  dependency-scan:
+    name: Dependency Scan
+    if: ${{ inputs.enable-dependency-scan }}
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-dependency-scan.yml@main
+    with:
+      dotnet-version: ${{ inputs.dotnet-version }}
+      runs-on: ${{ inputs.runs-on }}
+      working-directory: ${{ inputs.working-directory }}
+      project-path: ${{ inputs.project-path }}
+      fail-on-severity: ${{ inputs.dependency-fail-on-severity }}
+      actions-ref: ${{ inputs.actions-ref }}
+    permissions:
+      contents: read
+
+  # Job 5: CodeQL SAST / Code-Quality (Optional)
+  codeql:
+    name: CodeQL
+    if: ${{ inputs.enable-codeql }}
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-codeql.yml@main
+    with:
+      dotnet-version: ${{ inputs.dotnet-version }}
+      runs-on: ${{ inputs.runs-on }}
+      working-directory: ${{ inputs.working-directory }}
+      project-path: ${{ inputs.project-path }}
+      queries: ${{ inputs.codeql-queries }}
+      fail-on-severity: ${{ inputs.codeql-fail-on-severity }}
+      actions-ref: ${{ inputs.actions-ref }}
+    permissions:
+      contents: read
+      security-events: write
+
+  # Job 7: Accessibility Check (Optional)
   accessibility-check:
     name: Minimal Accessibility Check
     if: ${{ inputs.enable-accessibility-check }}
@@ -177,10 +238,10 @@ jobs:
           scan-mode: 'minimal'
           wcag-level: 'AA'
   
-  # Job 5: PR Summary
+  # Job 8: PR Summary
   pr-summary:
     name: PR Summary
-    needs: [build-and-test, static-analysis, secret-scan]
+    needs: [build-and-test, static-analysis, secret-scan, dependency-scan, codeql]
     if: ${{ always() && inputs.post-pr-summary }}
     runs-on: ${{ inputs.runs-on }}
     
@@ -225,28 +286,34 @@ jobs:
           BUILD_RESULT="${{ needs.build-and-test.result }}"
           ANALYSIS_RESULT="${{ needs.static-analysis.result }}"
           SECRETS_RESULT="${{ needs.secret-scan.result }}"
-          
+          DEPS_RESULT="${{ needs.dependency-scan.result }}"
+          CODEQL_RESULT="${{ needs.codeql.result }}"
+
           # Collect warnings - use empty defaults for skipped jobs
           BUILD_WARNINGS="${{ needs.build-and-test.outputs.has-warnings }}"
           ANALYSIS_WARNINGS="${{ needs.static-analysis.outputs.has-warnings }}"
           SECRETS_WARNINGS="${{ needs.secret-scan.outputs.has-warnings || 'false' }}"
-          
+          DEPS_WARNINGS="${{ needs.dependency-scan.outputs.has-warnings || 'false' }}"
+          CODEQL_WARNINGS="${{ needs.codeql.outputs.has-warnings || 'false' }}"
+
           BUILD_WARNING_MSG="${{ needs.build-and-test.outputs.warning-messages }}"
           ANALYSIS_WARNING_MSG="${{ needs.static-analysis.outputs.warning-messages }}"
           SECRETS_WARNING_MSG="${{ needs.secret-scan.outputs.warning-messages }}"
-          
+          DEPS_WARNING_MSG="${{ needs.dependency-scan.outputs.warning-messages }}"
+          CODEQL_WARNING_MSG="${{ needs.codeql.outputs.warning-messages }}"
+
           # Determine status - don't fail on skipped jobs
-          if [[ "$BUILD_RESULT" == "failure" || "$ANALYSIS_RESULT" == "failure" || "$SECRETS_RESULT" == "failure" ]]; then
+          if [[ "$BUILD_RESULT" == "failure" || "$ANALYSIS_RESULT" == "failure" || "$SECRETS_RESULT" == "failure" || "$DEPS_RESULT" == "failure" || "$CODEQL_RESULT" == "failure" ]]; then
             echo "icon=:x:" >> $GITHUB_OUTPUT
             echo "status=Failed" >> $GITHUB_OUTPUT
-          elif [[ "$BUILD_WARNINGS" == "true" || "$ANALYSIS_WARNINGS" == "true" || "$SECRETS_WARNINGS" == "true" ]]; then
+          elif [[ "$BUILD_WARNINGS" == "true" || "$ANALYSIS_WARNINGS" == "true" || "$SECRETS_WARNINGS" == "true" || "$DEPS_WARNINGS" == "true" || "$CODEQL_WARNINGS" == "true" ]]; then
             echo "icon=:warning:" >> $GITHUB_OUTPUT
             echo "status=Passed with Warnings" >> $GITHUB_OUTPUT
           else
             echo "icon=:white_check_mark:" >> $GITHUB_OUTPUT
             echo "status=Success" >> $GITHUB_OUTPUT
           fi
-          
+
           # Build warnings section
           WARNINGS_SECTION=""
           if [[ "$BUILD_WARNINGS" == "true" && -n "$BUILD_WARNING_MSG" ]]; then
@@ -261,7 +328,15 @@ jobs:
             WARNINGS_SECTION="${WARNINGS_SECTION}
           - :warning: **Secret Scan:** $SECRETS_WARNING_MSG"
           fi
-          
+          if [[ "$DEPS_WARNINGS" == "true" && -n "$DEPS_WARNING_MSG" ]]; then
+            WARNINGS_SECTION="${WARNINGS_SECTION}
+          - :warning: **Dependency Scan:** $DEPS_WARNING_MSG"
+          fi
+          if [[ "$CODEQL_WARNINGS" == "true" && -n "$CODEQL_WARNING_MSG" ]]; then
+            WARNINGS_SECTION="${WARNINGS_SECTION}
+          - :warning: **CodeQL:** $CODEQL_WARNING_MSG"
+          fi
+
           # Save to output
           {
             echo "warnings<<EOF"
@@ -276,6 +351,17 @@ jobs:
           JOB_BUILD_RESULT: ${{ needs.build-and-test.result }}
           JOB_STATIC_RESULT: ${{ needs.static-analysis.result }}
           JOB_SECRET_RESULT: ${{ needs.secret-scan.result }}
+          JOB_DEPS_RESULT: ${{ needs.dependency-scan.result }}
+          DEPS_FINDINGS: ${{ needs.dependency-scan.outputs.findings-count }}
+          DEPS_CRITICAL: ${{ needs.dependency-scan.outputs.critical-count }}
+          DEPS_HIGH: ${{ needs.dependency-scan.outputs.high-count }}
+          DEPS_MODERATE: ${{ needs.dependency-scan.outputs.moderate-count }}
+          DEPS_LOW: ${{ needs.dependency-scan.outputs.low-count }}
+          JOB_CODEQL_RESULT: ${{ needs.codeql.result }}
+          CODEQL_FINDINGS: ${{ needs.codeql.outputs.findings-count }}
+          CODEQL_ERROR: ${{ needs.codeql.outputs.error-count }}
+          CODEQL_WARNING: ${{ needs.codeql.outputs.warning-count }}
+          CODEQL_NOTE: ${{ needs.codeql.outputs.note-count }}
           WARNINGS_BLOCK: ${{ steps.status.outputs.warnings }}
           BUILD_CONFIGURATION: ${{ inputs.configuration }}
           RUNS_ON: ${{ inputs.runs-on }}
@@ -296,6 +382,35 @@ jobs:
 
           if [ "$JOB_SECRET_RESULT" != "skipped" ]; then
             echo "- **Secret Scan:** $JOB_SECRET_RESULT" >> message.md
+          fi
+
+          if [ "$JOB_DEPS_RESULT" != "skipped" ]; then
+            FINDINGS="${DEPS_FINDINGS:-0}"
+            if [ "$FINDINGS" -gt 0 ]; then
+              BREAKDOWN_PARTS=()
+              [ "${DEPS_CRITICAL:-0}" -gt 0 ] && BREAKDOWN_PARTS+=("${DEPS_CRITICAL} critical")
+              [ "${DEPS_HIGH:-0}"     -gt 0 ] && BREAKDOWN_PARTS+=("${DEPS_HIGH} high")
+              [ "${DEPS_MODERATE:-0}" -gt 0 ] && BREAKDOWN_PARTS+=("${DEPS_MODERATE} moderate")
+              [ "${DEPS_LOW:-0}"      -gt 0 ] && BREAKDOWN_PARTS+=("${DEPS_LOW} low")
+              BREAKDOWN=$(IFS=', '; echo "${BREAKDOWN_PARTS[*]}")
+              echo "- **Dependency Scan:** $JOB_DEPS_RESULT — ${FINDINGS} vulnerable package(s) (${BREAKDOWN})" >> message.md
+            else
+              echo "- **Dependency Scan:** $JOB_DEPS_RESULT — no vulnerable packages" >> message.md
+            fi
+          fi
+
+          if [ "$JOB_CODEQL_RESULT" != "skipped" ]; then
+            CQ_FINDINGS="${CODEQL_FINDINGS:-0}"
+            if [ "$CQ_FINDINGS" -gt 0 ]; then
+              CQ_PARTS=()
+              [ "${CODEQL_ERROR:-0}"   -gt 0 ] && CQ_PARTS+=("${CODEQL_ERROR} error")
+              [ "${CODEQL_WARNING:-0}" -gt 0 ] && CQ_PARTS+=("${CODEQL_WARNING} warning")
+              [ "${CODEQL_NOTE:-0}"    -gt 0 ] && CQ_PARTS+=("${CODEQL_NOTE} note")
+              CQ_BREAKDOWN=$(IFS=', '; echo "${CQ_PARTS[*]}")
+              echo "- **CodeQL:** $JOB_CODEQL_RESULT — ${CQ_FINDINGS} finding(s) (${CQ_BREAKDOWN})" >> message.md
+            else
+              echo "- **CodeQL:** $JOB_CODEQL_RESULT — no findings" >> message.md
+            fi
           fi
 
           if [ -n "$WARNINGS_BLOCK" ]; then

--- a/.github/workflows/pr-core.yml
+++ b/.github/workflows/pr-core.yml
@@ -68,7 +68,7 @@ on:
         default: true
 
       enable-dependency-scan:
-        description: 'Run vulnerable-package scan (dotnet list --vulnerable)'
+        description: 'Run vulnerable-package scan (dotnet list <target> package --vulnerable --include-transitive --format json)'
         required: false
         type: boolean
         default: true
@@ -206,7 +206,7 @@ jobs:
       contents: read
       security-events: write
 
-  # Job 7: Accessibility Check (Optional)
+  # Job 6: Accessibility Check (Optional)
   accessibility-check:
     name: Minimal Accessibility Check
     if: ${{ inputs.enable-accessibility-check }}
@@ -238,7 +238,7 @@ jobs:
           scan-mode: 'minimal'
           wcag-level: 'AA'
   
-  # Job 8: PR Summary
+  # Job 7: PR Summary
   pr-summary:
     name: PR Summary
     needs: [build-and-test, static-analysis, secret-scan, dependency-scan, codeql]
@@ -393,9 +393,9 @@ jobs:
               [ "${DEPS_MODERATE:-0}" -gt 0 ] && BREAKDOWN_PARTS+=("${DEPS_MODERATE} moderate")
               [ "${DEPS_LOW:-0}"      -gt 0 ] && BREAKDOWN_PARTS+=("${DEPS_LOW} low")
               BREAKDOWN=$(IFS=', '; echo "${BREAKDOWN_PARTS[*]}")
-              echo "- **Dependency Scan:** $JOB_DEPS_RESULT — ${FINDINGS} vulnerable package(s) (${BREAKDOWN})" >> message.md
+              echo "- **Dependency Scan:** $JOB_DEPS_RESULT — ${FINDINGS} vulnerabilities (${BREAKDOWN})" >> message.md
             else
-              echo "- **Dependency Scan:** $JOB_DEPS_RESULT — no vulnerable packages" >> message.md
+              echo "- **Dependency Scan:** $JOB_DEPS_RESULT — no vulnerabilities" >> message.md
             fi
           fi
 

--- a/.github/workflows/pr-sdk.yml
+++ b/.github/workflows/pr-sdk.yml
@@ -80,7 +80,7 @@ on:
         default: true
 
       enable-dependency-scan:
-        description: 'Run vulnerable-package scan (dotnet list --vulnerable)'
+        description: 'Run vulnerable-package scan (dotnet list <target> package --vulnerable --include-transitive --format json)'
         required: false
         type: boolean
         default: true
@@ -336,9 +336,9 @@ jobs:
             [ "${DEPS_MODERATE:-0}" -gt 0 ] && PARTS+=("${DEPS_MODERATE} moderate")
             [ "${DEPS_LOW:-0}"      -gt 0 ] && PARTS+=("${DEPS_LOW} low")
             BREAKDOWN=$(IFS=', '; echo "${PARTS[*]}")
-            echo "line=**Dependency Scan:** ${JOB_DEPS_RESULT} — ${FINDINGS} vulnerable package(s) (${BREAKDOWN})" >> "$GITHUB_OUTPUT"
+            echo "line=**Dependency Scan:** ${JOB_DEPS_RESULT} — ${FINDINGS} vulnerabilities (${BREAKDOWN})" >> "$GITHUB_OUTPUT"
           else
-            echo "line=**Dependency Scan:** ${JOB_DEPS_RESULT} — no vulnerable packages" >> "$GITHUB_OUTPUT"
+            echo "line=**Dependency Scan:** ${JOB_DEPS_RESULT} — no vulnerabilities" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build codeql line

--- a/.github/workflows/pr-sdk.yml
+++ b/.github/workflows/pr-sdk.yml
@@ -78,7 +78,37 @@ on:
         required: false
         type: boolean
         default: true
-      
+
+      enable-dependency-scan:
+        description: 'Run vulnerable-package scan (dotnet list --vulnerable)'
+        required: false
+        type: boolean
+        default: true
+
+      dependency-fail-on-severity:
+        description: 'Minimum vulnerability severity that fails the PR (critical, high, moderate, low, none)'
+        required: false
+        type: string
+        default: 'high'
+
+      enable-codeql:
+        description: 'Run CodeQL SAST / code-quality scan on the PR'
+        required: false
+        type: boolean
+        default: true
+
+      codeql-queries:
+        description: 'CodeQL query suite to run (security-and-quality, security-extended, security)'
+        required: false
+        type: string
+        default: 'security-and-quality'
+
+      codeql-fail-on-severity:
+        description: 'Lowest SARIF severity that fails the PR (error, warning, note, none)'
+        required: false
+        type: string
+        default: 'note'
+
       post-pr-summary:
         description: 'Post results summary to PR as comment'
         required: false
@@ -157,7 +187,6 @@ jobs:
       project-path: ${{ inputs.project-path }}
       check-formatting: true
       fail-on-formatting-issues: false  # Warn only in PR
-      fail-on-severity: 'high'
       validate-test-naming: true
       actions-ref: ${{ inputs.actions-ref }}
     permissions:
@@ -174,8 +203,40 @@ jobs:
       actions-ref: ${{ inputs.actions-ref }}
     permissions:
       contents: read
-  
-  # Job 6: Documentation Check
+
+  # Job 6: Dependency Vulnerability Scan (Optional)
+  dependency-scan:
+    name: Dependency Scan
+    if: ${{ inputs.enable-dependency-scan }}
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-dependency-scan.yml@main
+    with:
+      dotnet-version: ${{ inputs.dotnet-version }}
+      runs-on: ${{ inputs.runs-on }}
+      working-directory: ${{ inputs.working-directory }}
+      project-path: ${{ inputs.project-path }}
+      fail-on-severity: ${{ inputs.dependency-fail-on-severity }}
+      actions-ref: ${{ inputs.actions-ref }}
+    permissions:
+      contents: read
+
+  # Job 7: CodeQL SAST / Code-Quality (Optional)
+  codeql:
+    name: CodeQL
+    if: ${{ inputs.enable-codeql }}
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-codeql.yml@main
+    with:
+      dotnet-version: ${{ inputs.dotnet-version }}
+      runs-on: ${{ inputs.runs-on }}
+      working-directory: ${{ inputs.working-directory }}
+      project-path: ${{ inputs.project-path }}
+      queries: ${{ inputs.codeql-queries }}
+      fail-on-severity: ${{ inputs.codeql-fail-on-severity }}
+      actions-ref: ${{ inputs.actions-ref }}
+    permissions:
+      contents: read
+      security-events: write
+
+  # Job 8: Documentation Check
   documentation-check:
     name: Documentation Check
     runs-on: ${{ inputs.runs-on }}
@@ -209,42 +270,106 @@ jobs:
           project-path: ${{ inputs.project-path }}
           treat-as-error: 'true'
   
-  # Job 7: PR Summary
+  # Job 9: PR Summary
   pr-summary:
     name: PR Summary
-    needs: [build-and-test, coverage-analysis, api-compatibility, static-analysis]
+    needs: [build-and-test, coverage-analysis, api-compatibility, static-analysis, dependency-scan, codeql]
     if: ${{ always() && inputs.post-pr-summary }}
     runs-on: ${{ inputs.runs-on }}
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Checkout HoneyDrunk.Actions
         uses: actions/checkout@v4
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
           ref: ${{ inputs.actions-ref }}
-      
+
       - name: Generate PR summary
         uses: ./.github/actions-repo/.github/actions/pr/generate-summary
-      
+
       - name: Determine job status
         id: status
         shell: bash
         run: |
+          DEPS_RESULT="${{ needs.dependency-scan.result }}"
+          CODEQL_RESULT="${{ needs.codeql.result }}"
           if [[ "${{ needs.build-and-test.result }}" == "success" && \
                 "${{ needs.coverage-analysis.result }}" == "success" && \
                 "${{ needs.api-compatibility.result }}" == "success" && \
-                "${{ needs.static-analysis.result }}" == "success" ]]; then
+                "${{ needs.static-analysis.result }}" == "success" && \
+                ("$DEPS_RESULT" == "success" || "$DEPS_RESULT" == "skipped") && \
+                ("$CODEQL_RESULT" == "success" || "$CODEQL_RESULT" == "skipped") ]]; then
             echo "icon=:white_check_mark:" >> $GITHUB_OUTPUT
             echo "status=Success" >> $GITHUB_OUTPUT
           else
             echo "icon=:x:" >> $GITHUB_OUTPUT
             echo "status=Failed" >> $GITHUB_OUTPUT
           fi
-      
+
+      - name: Build dependency-scan line
+        id: deps-line
+        shell: bash
+        env:
+          JOB_DEPS_RESULT: ${{ needs.dependency-scan.result }}
+          DEPS_FINDINGS: ${{ needs.dependency-scan.outputs.findings-count }}
+          DEPS_CRITICAL: ${{ needs.dependency-scan.outputs.critical-count }}
+          DEPS_HIGH: ${{ needs.dependency-scan.outputs.high-count }}
+          DEPS_MODERATE: ${{ needs.dependency-scan.outputs.moderate-count }}
+          DEPS_LOW: ${{ needs.dependency-scan.outputs.low-count }}
+        run: |
+          set -euo pipefail
+
+          if [ "$JOB_DEPS_RESULT" = "skipped" ]; then
+            echo "line=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          FINDINGS="${DEPS_FINDINGS:-0}"
+          if [ "$FINDINGS" -gt 0 ]; then
+            PARTS=()
+            [ "${DEPS_CRITICAL:-0}" -gt 0 ] && PARTS+=("${DEPS_CRITICAL} critical")
+            [ "${DEPS_HIGH:-0}"     -gt 0 ] && PARTS+=("${DEPS_HIGH} high")
+            [ "${DEPS_MODERATE:-0}" -gt 0 ] && PARTS+=("${DEPS_MODERATE} moderate")
+            [ "${DEPS_LOW:-0}"      -gt 0 ] && PARTS+=("${DEPS_LOW} low")
+            BREAKDOWN=$(IFS=', '; echo "${PARTS[*]}")
+            echo "line=**Dependency Scan:** ${JOB_DEPS_RESULT} — ${FINDINGS} vulnerable package(s) (${BREAKDOWN})" >> "$GITHUB_OUTPUT"
+          else
+            echo "line=**Dependency Scan:** ${JOB_DEPS_RESULT} — no vulnerable packages" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build codeql line
+        id: codeql-line
+        shell: bash
+        env:
+          JOB_CODEQL_RESULT: ${{ needs.codeql.result }}
+          CODEQL_FINDINGS: ${{ needs.codeql.outputs.findings-count }}
+          CODEQL_ERROR: ${{ needs.codeql.outputs.error-count }}
+          CODEQL_WARNING: ${{ needs.codeql.outputs.warning-count }}
+          CODEQL_NOTE: ${{ needs.codeql.outputs.note-count }}
+        run: |
+          set -euo pipefail
+
+          if [ "$JOB_CODEQL_RESULT" = "skipped" ]; then
+            echo "line=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          FINDINGS="${CODEQL_FINDINGS:-0}"
+          if [ "$FINDINGS" -gt 0 ]; then
+            PARTS=()
+            [ "${CODEQL_ERROR:-0}"   -gt 0 ] && PARTS+=("${CODEQL_ERROR} error")
+            [ "${CODEQL_WARNING:-0}" -gt 0 ] && PARTS+=("${CODEQL_WARNING} warning")
+            [ "${CODEQL_NOTE:-0}"    -gt 0 ] && PARTS+=("${CODEQL_NOTE} note")
+            BREAKDOWN=$(IFS=', '; echo "${PARTS[*]}")
+            echo "line=**CodeQL:** ${JOB_CODEQL_RESULT} — ${FINDINGS} finding(s) (${BREAKDOWN})" >> "$GITHUB_OUTPUT"
+          else
+            echo "line=**CodeQL:** ${JOB_CODEQL_RESULT} — no findings" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Post PR comment
         continue-on-error: true
         uses: ./.github/actions-repo/.github/actions/pr/post-comment
@@ -252,12 +377,14 @@ jobs:
           github-token: ${{ secrets.github-token || github.token }}
           message: |
             ## ${{ steps.status.outputs.icon }} PR SDK Validation ${{ steps.status.outputs.status }}
-            
+
             **Build and Test:** ${{ needs.build-and-test.result }}
             **Coverage Analysis:** ${{ needs.coverage-analysis.result }}
             **API Compatibility:** ${{ needs.api-compatibility.result }}
             **Static Analysis:** ${{ needs.static-analysis.result }}
-            
+            ${{ steps.deps-line.outputs.line }}
+            ${{ steps.codeql-line.outputs.line }}
+
             **Configuration:** ${{ inputs.configuration }}
             **Coverage Threshold:** ${{ inputs.coverage-threshold }}%
             **Runner:** ${{ inputs.runs-on }}

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Fast validation for pull requests:
   - Build and unit tests
   - Fast static analysis (formatting, test naming)
   - Diff-only secret scanning
-  - Vulnerable-package scan (`dotnet list --vulnerable --include-transitive`)
+  - Vulnerable-package scan (`dotnet list package --vulnerable --include-transitive --format json`)
   - CodeQL SAST + code-quality (`security-and-quality` query pack)
   - Optional minimal accessibility check
   - Consolidated PR summary comment with per-job severity breakdowns

--- a/README.md
+++ b/README.md
@@ -39,15 +39,20 @@ Fast validation for pull requests:
 
 - **[pr-core.yml](.github/workflows/pr-core.yml)** - Basic PR validation for most repos
   - Build and unit tests
-  - Fast static analysis
+  - Fast static analysis (formatting, test naming)
   - Diff-only secret scanning
+  - Vulnerable-package scan (`dotnet list --vulnerable --include-transitive`)
+  - CodeQL SAST + code-quality (`security-and-quality` query pack)
   - Optional minimal accessibility check
-  
+  - Consolidated PR summary comment with per-job severity breakdowns
+
 - **[pr-sdk.yml](.github/workflows/pr-sdk.yml)** - Extended validation for SDK repos
-  - Everything in pr-core
+  - Everything in pr-core (incl. dependency scan + CodeQL)
   - API compatibility checks
   - Code coverage with delta reporting
   - Documentation completeness validation
+
+> **Consumer permission note:** both PR workflows upload SARIF to GitHub Code Scanning, which requires `security-events: write`. For least privilege, scope it on the calling job instead of the whole workflow — see [Quick Start](#quick-start) for the exact shape.
 
 ### Release Workflows
 
@@ -100,16 +105,19 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   pr-validation:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      security-events: write  # CodeQL SARIF upload
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-
-permissions:
-  contents: read
-  checks: write
-  pull-requests: write
 ```
 
 ### SDK/Library PR Workflow
@@ -123,18 +131,21 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   pr-sdk-validation:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      security-events: write  # CodeQL SARIF upload
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-sdk.yml@main
     with:
       coverage-threshold: 80
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-
-permissions:
-  contents: read
-  checks: write
-  pull-requests: write
 ```
 
 ### Release Workflow

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the GitHub Actions template library will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-04-18
+
+### Added
+- `job-dependency-scan.yml`: PR-time vulnerable-package scan (`dotnet list package --vulnerable --include-transitive`). Emits severity counts, uploads JSON report artifact, fails on configurable severity threshold.
+- `pr-core.yml`: wired in the dependency-scan job as optional (default on), with `enable-dependency-scan` and `dependency-fail-on-severity` inputs. Results appear in the PR summary comment alongside existing jobs.
+- `pr-sdk.yml`: same dependency-scan wiring for SDK/library repos; findings + severity breakdown show up in the SDK PR comment.
+- `job-codeql.yml`: PR-time CodeQL SAST + code-quality scan using the `security-and-quality` query pack (same suite nightly runs). Uploads SARIF to Code Scanning under a `pr-sast` category, emits severity counts, and fails the PR at or above a configurable SARIF level (default: any finding).
+- `pr-core.yml` and `pr-sdk.yml`: wired in the CodeQL job as optional (default on) with `enable-codeql`, `codeql-queries`, and `codeql-fail-on-severity` inputs. Findings + severity breakdown appear in the PR summary comment.
+
+### Changed
+- `job-static-analysis.yml`: removed the vulnerability scan step (now owned by `job-dependency-scan.yml`) and dropped its `fail-on-severity` input. `pr-core.yml` and `pr-sdk.yml` no longer pass that input.
+
 ## [1.0.0] - 2025-01-07
 
 ### Added

--- a/docs/consumer-usage.md
+++ b/docs/consumer-usage.md
@@ -45,8 +45,20 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read  # broader writes are granted per-job (least privilege)
+
 jobs:
   pr-validation:
+    # security-events: write is scoped here because pr-core's CodeQL step
+    # uploads SARIF to GitHub Code Scanning. checks: write and
+    # pull-requests: write are scoped here too so additional jobs don't
+    # inherit them implicitly.
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      security-events: write
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
     with:
       dotnet-version: '10.0.x'
@@ -55,16 +67,16 @@ jobs:
       working-directory: '.'
       project-path: './src/MyProject.sln'
       enable-secret-scan: true
+      enable-dependency-scan: true
+      dependency-fail-on-severity: 'high'
+      enable-codeql: true
+      codeql-queries: 'security-and-quality'
+      codeql-fail-on-severity: 'note'   # any finding blocks; set 'warning' or 'error' to loosen
       enable-accessibility-check: false
       post-pr-summary: true
       actions-ref: 'main'
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-
-permissions:
-  contents: read
-  checks: write
-  pull-requests: write
 ```
 
 ### Web App with Accessibility Check
@@ -76,19 +88,22 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   pr-validation:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      security-events: write  # CodeQL SARIF upload
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
     with:
       enable-accessibility-check: true
       accessibility-url: 'http://localhost:5000'
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-
-permissions:
-  contents: read
-  checks: write
-  pull-requests: write
 ```
 
 ---
@@ -108,16 +123,19 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   pr-sdk-validation:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      security-events: write  # CodeQL SARIF upload
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-sdk.yml@main
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-
-permissions:
-  contents: read
-  checks: write
-  pull-requests: write
 ```
 
 ### Full Example with Coverage and API Baseline
@@ -129,8 +147,16 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   pr-sdk-validation:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      security-events: write  # CodeQL SARIF upload
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-sdk.yml@main
     with:
       dotnet-version: '10.0.x'
@@ -142,11 +168,6 @@ jobs:
       post-pr-summary: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-
-permissions:
-  contents: read
-  checks: write
-  pull-requests: write
 ```
 
 ---


### PR DESCRIPTION
introduce job-dependency-scan.yml for PR-time vulnerable-package scanning and job-codeql.yml for CodeQL SAST/code-quality analysis; wire both into pr-core.yml and pr-sdk.yml as optional, configurable jobs with severity gating; enhance PR summary with findings breakdown; remove vuln scan from static analysis; update docs and changelog for 1.0.1