### PR TITLE
fix(ci): ship shared CodeQL config that ignores generated code

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,12 @@
+name: HoneyDrunk Grid default CodeQL config
+
+# Shared CodeQL configuration used by job-codeql.yml when a consuming repo
+# does not ship its own ./.github/codeql/codeql-config.yml. Repos can override
+# by creating that file locally.
+
+paths-ignore:
+  - '**/obj/**'
+  - '**/bin/**'
+  - '**/*.g.cs'
+  - '**/*.Designer.cs'
+  - '**/*.AssemblyInfo.cs'

--- a/.github/workflows/job-codeql.yml
+++ b/.github/workflows/job-codeql.yml
@@ -114,16 +114,25 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Detect repo-local CodeQL config
+      - name: Checkout HoneyDrunk.Actions
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          path: .github/actions-repo
+          ref: ${{ inputs.actions-ref }}
+
+      - name: Resolve CodeQL config
         id: codeql-config
         shell: bash
         run: |
+          # Prefer a repo-local config if the consuming repo ships one; otherwise
+          # fall back to the shared default shipped by HoneyDrunk.Actions.
           if [ -f "./.github/codeql/codeql-config.yml" ]; then
             echo "path=./.github/codeql/codeql-config.yml" >> $GITHUB_OUTPUT
           elif [ -f "./.github/codeql/codeql-config.yaml" ]; then
             echo "path=./.github/codeql/codeql-config.yaml" >> $GITHUB_OUTPUT
           else
-            echo "path=" >> $GITHUB_OUTPUT
+            echo "path=./.github/actions-repo/.github/codeql/codeql-config.yml" >> $GITHUB_OUTPUT
           fi
 
       - name: Initialize CodeQL
@@ -132,13 +141,6 @@ jobs:
           languages: ${{ inputs.languages }}
           queries: ${{ inputs.queries }}
           config-file: ${{ steps.codeql-config.outputs.path }}
-
-      - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
-        with:
-          repository: HoneyDrunkStudios/HoneyDrunk.Actions
-          path: .github/actions-repo
-          ref: ${{ inputs.actions-ref }}
 
       - name: Setup .NET SDK
         uses: ./.github/actions-repo/.github/actions/dotnet/setup

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -203,16 +203,25 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Detect repo-local CodeQL config
+      - name: Checkout HoneyDrunk.Actions
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          path: .github/actions-repo
+          ref: ${{ inputs.actions-ref }}
+
+      - name: Resolve CodeQL config
         id: codeql-config
         shell: bash
         run: |
+          # Prefer a repo-local config; otherwise fall back to the shared
+          # default shipped by HoneyDrunk.Actions.
           if [ -f "./.github/codeql/codeql-config.yml" ]; then
             echo "path=./.github/codeql/codeql-config.yml" >> $GITHUB_OUTPUT
           elif [ -f "./.github/codeql/codeql-config.yaml" ]; then
             echo "path=./.github/codeql/codeql-config.yaml" >> $GITHUB_OUTPUT
           else
-            echo "path=" >> $GITHUB_OUTPUT
+            echo "path=./.github/actions-repo/.github/codeql/codeql-config.yml" >> $GITHUB_OUTPUT
           fi
 
       - name: Initialize CodeQL
@@ -221,13 +230,6 @@ jobs:
           languages: csharp
           queries: security-and-quality
           config-file: ${{ steps.codeql-config.outputs.path }}
-
-      - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
-        with:
-          repository: HoneyDrunkStudios/HoneyDrunk.Actions
-          path: .github/actions-repo
-          ref: ${{ inputs.actions-ref }}
 
       - name: Setup .NET SDK
         uses: ./.github/actions-repo/.github/actions/dotnet/setup


### PR DESCRIPTION
## Summary
- Adds [`.github/codeql/codeql-config.yml`](.github/codeql/codeql-config.yml) with `paths-ignore` for `obj/**`, `bin/**`, `*.g.cs`, `*.Designer.cs`, `*.AssemblyInfo.cs`.
- Updates [`job-codeql.yml`](.github/workflows/job-codeql.yml) so that when a consuming repo doesn't ship its own `./.github/codeql/codeql-config.yml`, CodeQL falls back to the shared default from this repo. Repos can still override locally.

## Why
Kernel (and likely others as we wire up more repos) were getting CodeQL findings in `obj/Debug/.../RegexGenerator.g.cs` — auto-generated by the regex source generator. That code isn't editable source; excluding it at the scan boundary is the right fix.

## Test plan
- [ ] Workflow still validates
- [ ] Next CodeQL run on a consumer (e.g. HoneyDrunk.Kernel) reports zero generated-code findings
- [ ] A repo with a local `codeql-config.yml` still uses its own config (override path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)