### PR TITLE
fix(ci): widen validate-test-naming defaults, downgrade to warning

### DIFF
--- a/.github/actions/diagnostics/validate-test-naming/action.yml
+++ b/.github/actions/diagnostics/validate-test-naming/action.yml
@@ -7,23 +7,52 @@ inputs:
     required: false
     default: '.'
   pattern:
-    description: 'Regex pattern for test file names'
+    description: 'Regex pattern for test file names (also implicitly accepts common support suffixes: Helper, Fixture, Builder, Factory, Fake, Mock, Stub, TestBase, TestData, TestConstants, Assertions)'
     required: false
-    default: '.*Tests?\.cs$'
+    default: '.*(Tests?|TestBase|TestData|TestConstants|Fixture|Fixtures|Helper|Helpers|Builder|Builders|Factory|Factories|Fake|Fakes|Mock|Mocks|Stub|Stubs|Assertion|Assertions)\.cs$'
+  strict:
+    description: 'Treat naming violations as errors that fail the step. When false (default), violations are emitted as warnings and the step exits 0.'
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
     - name: Validate test naming conventions
       shell: bash
       working-directory: ${{ inputs.test-directory }}
+      env:
+        PATTERN: ${{ inputs.pattern }}
+        STRICT: ${{ inputs.strict }}
       run: |
+        set -euo pipefail
         echo "Checking test file naming conventions..."
-        INVALID_FILES=$(find . -type f -name "*.cs" -path "*/Test*/*" ! -regex "${{ inputs.pattern }}" | grep -i test || true)
-        
-        if [ -n "$INVALID_FILES" ]; then
+
+        # Flag .cs files under a "Test*" project directory that don't match the
+        # accepted-names pattern. Exclude common support-code subdirectories so
+        # helpers/fixtures/fakes don't get wrongly flagged even when named
+        # without the Tests suffix.
+        INVALID_FILES=$(find . -type f -name "*.cs" -path "*/Test*/*" \
+          -not -path "*/TestHelpers/*" \
+          -not -path "*/Helpers/*" \
+          -not -path "*/Fixtures/*" \
+          -not -path "*/Fakes/*" \
+          -not -path "*/Mocks/*" \
+          -not -path "*/Stubs/*" \
+          -not -path "*/Builders/*" \
+          -not -path "*/obj/*" \
+          -not -path "*/bin/*" \
+          ! -regex "${PATTERN}" || true)
+
+        if [ -z "$INVALID_FILES" ]; then
+          echo "✅ All test files follow naming conventions"
+          exit 0
+        fi
+
+        if [ "$STRICT" = "true" ]; then
           echo "::error::Found test files that don't match naming convention:"
           echo "$INVALID_FILES"
           exit 1
         else
-          echo "? All test files follow naming conventions"
+          echo "::warning::Found test files that don't match naming convention (informational; pass strict=true to fail the step):"
+          echo "$INVALID_FILES"
         fi

--- a/.github/actions/diagnostics/validate-test-naming/action.yml
+++ b/.github/actions/diagnostics/validate-test-naming/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: '.'
   pattern:
-    description: 'Regex pattern for test file names (also implicitly accepts common support suffixes: Helper, Fixture, Builder, Factory, Fake, Mock, Stub, TestBase, TestData, TestConstants, Assertions)'
+    description: 'POSIX extended regex for accepted test file names. The default also accepts common support suffixes (Helper, Fixture, Builder, Factory, Fake, Mock, Stub, TestBase, TestData, TestConstants, Assertions). If you override this, supply the full allow-list.'
     required: false
     default: '.*(Tests?|TestBase|TestData|TestConstants|Fixture|Fixtures|Helper|Helpers|Builder|Builders|Factory|Factories|Fake|Fakes|Mock|Mocks|Stub|Stubs|Assertion|Assertions)\.cs$'
   strict:
@@ -31,7 +31,11 @@ runs:
         # accepted-names pattern. Exclude common support-code subdirectories so
         # helpers/fixtures/fakes don't get wrongly flagged even when named
         # without the Tests suffix.
-        INVALID_FILES=$(find . -type f -name "*.cs" -path "*/Test*/*" \
+        # GNU find defaults -regex to Emacs syntax; the default pattern is
+        # POSIX ERE, so select the matching regextype explicitly. Callers
+        # overriding `pattern` should supply POSIX-extended regex too.
+        INVALID_FILES=$(find . -regextype posix-extended \
+          -type f -name "*.cs" -path "*/Test*/*" \
           -not -path "*/TestHelpers/*" \
           -not -path "*/Helpers/*" \
           -not -path "*/Fixtures/*" \


### PR DESCRIPTION
## Summary
Two issues surfaced on HoneyDrunk.Kernel's `PR Core / Static Analysis` annotations tab:

1. Legitimate support files (e.g. `HoneyDrunk.Kernel.Tests/TestHelpers/GridContextTestHelper.cs`) were flagged as "tests with wrong naming" because the default regex only accepted `*Tests.cs` / `*Test.cs`.
2. The step emitted `::error::` so the annotation rendered as a red error on the PR even though the caller sets `continue-on-error: true`.

## Changes
- **Broaden default pattern** to accept common test-support suffixes: `Helper(s)`, `Fixture(s)`, `Builder(s)`, `Factory/Factories`, `Fake(s)`, `Mock(s)`, `Stub(s)`, `TestBase`, `TestData`, `TestConstants`, `Assertion(s)`.
- **Exclude support subdirectories** in `find` so helpers/fixtures aren't scanned at all: `TestHelpers/`, `Helpers/`, `Fixtures/`, `Fakes/`, `Mocks/`, `Stubs/`, `Builders/`, `obj/`, `bin/`.
- **Add `strict` input** (default `false`). When false the step emits `::warning::` and exits 0 — annotation shows up yellow on the PR, doesn't block. `strict=true` restores the old error-and-exit-1 behaviour for repos that want it gating.

## Test plan
- [ ] Re-run HoneyDrunk.Kernel PR Core static-analysis — no more error-level annotation for `GridContextTestHelper.cs`
- [ ] A consumer passing `strict: true` still gets an error on genuine misnamed tests
- [ ] `*Tests.cs` and `*Test.cs` files still accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)