### PR TITLE
fix(file-packets): skip non-packet markdown without frontmatter

### DIFF
--- a/.github/workflows/file-packets.yml
+++ b/.github/workflows/file-packets.yml
@@ -112,6 +112,11 @@ jobs:
             --mapping-file ./honeydrunk-actions/.github/config/repo-to-node.yml
 
       - name: Commit updated manifest
+        # Run even if `File packets` errored partway through, so any packets
+        # that WERE successfully filed get persisted to the manifest. Without
+        # this, a single bad packet mid-run loses state for every packet that
+        # filed before it — causing duplicate issues on the next run.
+        if: always()
         working-directory: architecture
         env:
           MANIFEST_PATH: ${{ inputs.manifest-path }}

--- a/.github/workflows/file-packets.yml
+++ b/.github/workflows/file-packets.yml
@@ -74,6 +74,7 @@ jobs:
           fi
 
       - name: Checkout HoneyDrunk.Architecture
+        id: checkout-architecture
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.architecture-repo }}
@@ -115,8 +116,10 @@ jobs:
         # Run even if `File packets` errored partway through, so any packets
         # that WERE successfully filed get persisted to the manifest. Without
         # this, a single bad packet mid-run loses state for every packet that
-        # filed before it — causing duplicate issues on the next run.
-        if: always()
+        # filed before it — causing duplicate issues on the next run. Gated on
+        # the architecture checkout succeeding so we don't try to commit into a
+        # non-existent working directory when earlier steps fail.
+        if: always() && steps.checkout-architecture.outcome == 'success'
         working-directory: architecture
         env:
           MANIFEST_PATH: ${{ inputs.manifest-path }}

--- a/scripts/file-packets.sh
+++ b/scripts/file-packets.sh
@@ -114,7 +114,17 @@ body = raw
 has_frontmatter = False
 m = re.match(r"^---\r?\n(.*?)\r?\n---\r?\n(.*)$", raw, re.DOTALL)
 if m:
-    fm = yaml.safe_load(m.group(1)) or {}
+    loaded = yaml.safe_load(m.group(1))
+    if loaded is None:
+        fm = {}
+    elif isinstance(loaded, dict):
+        fm = loaded
+    else:
+        print(
+            f"Frontmatter in {path} is not a YAML mapping (got {type(loaded).__name__})",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     body = m.group(2).lstrip("\n")
     has_frontmatter = True
 

--- a/scripts/file-packets.sh
+++ b/scripts/file-packets.sh
@@ -111,10 +111,12 @@ with open(path, encoding="utf-8") as f:
 
 fm = {}
 body = raw
+has_frontmatter = False
 m = re.match(r"^---\r?\n(.*?)\r?\n---\r?\n(.*)$", raw, re.DOTALL)
 if m:
     fm = yaml.safe_load(m.group(1)) or {}
     body = m.group(2).lstrip("\n")
+    has_frontmatter = True
 
 title = ""
 for line in body.splitlines():
@@ -133,6 +135,7 @@ def as_list(v):
 out = {
     "title": title,
     "body": body,
+    "has_frontmatter": has_frontmatter,
     "target_repo": str(fm.get("target_repo", "")).strip(),
     "labels": as_list(fm.get("labels")),
     "initiative": str(fm.get("initiative", "")).strip(),
@@ -217,6 +220,16 @@ for packet in "$PACKETS_DIR_ABS"/**/*.md; do
   fi
 
   packet_json="$(parse_packet "$packet")"
+  has_frontmatter="$(jq -r '.has_frontmatter' <<<"$packet_json")"
+
+  # Files without YAML frontmatter are coordination docs (dispatch-plan.md,
+  # READMEs, notes), not packets. Skip quietly so non-packet markdown can live
+  # alongside packets in the same directory.
+  if [[ "$has_frontmatter" != "true" ]]; then
+    echo "skip  $rel -> no frontmatter (not a packet)"
+    continue
+  fi
+
   title="$(jq -r '.title' <<<"$packet_json")"
   body_content="$(jq -r '.body' <<<"$packet_json")"
   target_repo="$(jq -r '.target_repo' <<<"$packet_json")"


### PR DESCRIPTION
Detect and skip markdown files lacking YAML frontmatter as non-packet docs, preventing errors and duplicate filings. Add workflow comment clarifying manifest commit always runs to persist partial progress.