### PR TITLE
fix(ci): IaC detect step crashes on first match under set -e

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -407,19 +407,19 @@ jobs:
           IAC_COUNT=0
           if find . \( -name "*.tf" -o -name "*.tfvars" \) | grep -q .; then
             echo "Terraform files detected"
-            ((IAC_COUNT++))
+            IAC_COUNT=$((IAC_COUNT + 1))
           fi
           if find . \( -name "*.bicep" -o -name "*.json" \) | xargs grep -l "Microsoft.Resources" 2>/dev/null | grep -q .; then
             echo "Azure Bicep/ARM templates detected"
-            ((IAC_COUNT++))
+            IAC_COUNT=$((IAC_COUNT + 1))
           fi
           if find . \( -name "docker-compose*.yml" -o -name "Dockerfile*" \) | grep -q .; then
             echo "Docker files detected"
-            ((IAC_COUNT++))
+            IAC_COUNT=$((IAC_COUNT + 1))
           fi
           if find . \( -name "*.yaml" -o -name "*.yml" \) | xargs grep -l "apiVersion:" 2>/dev/null | grep -q .; then
             echo "Kubernetes manifests detected"
-            ((IAC_COUNT++))
+            IAC_COUNT=$((IAC_COUNT + 1))
           fi
           
           if [ $IAC_COUNT -gt 0 ]; then


### PR DESCRIPTION
## Summary
- `((IAC_COUNT++))` returns the **pre-increment value** (0) on the first match, and a `(( ))` expression evaluating to 0 has exit code 1. Combined with GitHub Actions' default `shell: bash` (`set -eo pipefail`), the step dies the moment any IaC file is detected.
- Every consumer repo with a `Dockerfile` (Notify, Pulse, and others) fails the **Infrastructure as Code Security Scan** job nightly. Other security jobs (SAST, Secrets, Deps) pass — only this step is broken.
- Replace the four `((IAC_COUNT++))` with `IAC_COUNT=\$((IAC_COUNT + 1))`. Plain arithmetic assignment doesn't carry the exit-code subtlety.

## Failing runs that triggered this
- Notify: https://github.com/HoneyDrunkStudios/HoneyDrunk.Notify/actions/runs/24974505358/job/73123621563
- Pulse: https://github.com/HoneyDrunkStudios/HoneyDrunk.Pulse/actions/runs/24974702400/job/73124216835

Both fail in ~5s right after detecting Docker files — consistent with the diagnosis.

## Out of scope (separate concerns)
- Node 20 / CodeQL v3 deprecation warnings on this and sibling jobs.
- `xargs` without `-r` in the bicep/k8s detection branches (latent issue if those globs match nothing).

## Test plan
- [ ] Merge to `main`.
- [ ] Manually re-run a nightly-security workflow on Notify or Pulse and confirm the IaC job goes green (or skips cleanly with `has_iac=false`).
- [ ] Spot-check one non-Docker consumer to ensure the empty path still reports `has_iac=false` and the dependent steps skip.