### PR TITLE
fix(ci): filter generated-code findings from SARIF before upload

### DIFF
--- a/.github/actions/security/filter-sarif/action.yml
+++ b/.github/actions/security/filter-sarif/action.yml
@@ -11,8 +11,9 @@ inputs:
     required: true
   pattern:
     description: >-
-      Regex (jq `test`) matched against each result's primary
-      `location.uri`; matching results are dropped.
+      Regex (jq `test`) matched against each result's
+      `locations[].physicalLocation.artifactLocation.uri`; results are
+      dropped if any location URI matches.
     required: false
     default: '(^|/)(obj|bin)/|\.g\.cs$|\.Designer\.cs$|\.AssemblyInfo\.cs$'
 runs:

--- a/.github/actions/security/filter-sarif/action.yml
+++ b/.github/actions/security/filter-sarif/action.yml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+name: 'Filter generated-code findings from SARIF'
+description: >-
+  Strip results pointing to generated/build-output files from CodeQL SARIF
+  before upload. Works around the CodeQL `paths-ignore` limitation on compiled
+  languages (C#/Java/Go/Kotlin) — those files get extracted as a side effect
+  of the build and re-appear as alerts no matter what the config file says.
+inputs:
+  sarif-dir:
+    description: 'Directory containing *.sarif files to filter (in place)'
+    required: true
+  pattern:
+    description: >-
+      Regex (jq `test`) matched against each result's primary
+      `location.uri`; matching results are dropped.
+    required: false
+    default: '(^|/)(obj|bin)/|\.g\.cs$|\.Designer\.cs$|\.AssemblyInfo\.cs$'
+runs:
+  using: 'composite'
+  steps:
+    - name: Filter SARIF files
+      shell: bash
+      env:
+        SARIF_DIR: ${{ inputs.sarif-dir }}
+        FILTER_PATTERN: ${{ inputs.pattern }}
+      run: |
+        set -euo pipefail
+
+        if [ ! -d "$SARIF_DIR" ]; then
+          echo "::warning::SARIF directory '$SARIF_DIR' not found; nothing to filter."
+          exit 0
+        fi
+
+        shopt -s nullglob
+        files=("$SARIF_DIR"/*.sarif)
+        if [ "${#files[@]}" -eq 0 ]; then
+          echo "::warning::No *.sarif files in '$SARIF_DIR'; nothing to filter."
+          exit 0
+        fi
+
+        for f in "${files[@]}"; do
+          before=$(jq '[.runs[].results[]?] | length' "$f")
+          jq --arg pat "$FILTER_PATTERN" '
+            .runs[].results |= map(
+              select(
+                ([.locations[]?.physicalLocation.artifactLocation.uri // ""]
+                  | map(test($pat)) | any) | not
+              )
+            )
+          ' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+          after=$(jq '[.runs[].results[]?] | length' "$f")
+          dropped=$((before - after))
+          echo "$(basename "$f"): $before → $after results (dropped $dropped generated-code findings)"
+        done

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,6 +3,14 @@ name: HoneyDrunk Grid default CodeQL config
 # Shared CodeQL configuration used by job-codeql.yml when a consuming repo
 # does not ship its own ./.github/codeql/codeql-config.yml. Repos can override
 # by creating that file locally.
+#
+# NOTE: `paths-ignore` is documented as ineffective for compiled languages
+# (C#/Java/Go/Kotlin) — generated files are extracted as a side effect of
+# the build and re-appear as alerts regardless of this list. The actual
+# enforcement happens in the `security/filter-sarif` composite action,
+# which strips matching results from the SARIF before upload. This list
+# is kept for parity with non-compiled-language repos and as documentation
+# of intent.
 
 paths-ignore:
   - '**/obj/**'

--- a/.github/workflows/job-codeql.yml
+++ b/.github/workflows/job-codeql.yml
@@ -171,7 +171,18 @@ jobs:
         with:
           category: ${{ inputs.category }}
           output: ${{ inputs.working-directory }}/codeql-results
-          upload: true
+          upload: never
+
+      - name: Filter generated-code findings from SARIF
+        uses: ./.github/actions-repo/.github/actions/security/filter-sarif
+        with:
+          sarif-dir: ${{ inputs.working-directory }}/codeql-results
+
+      - name: Upload filtered SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ inputs.working-directory }}/codeql-results
+          category: ${{ inputs.category }}
           wait-for-processing: true
 
       - name: Evaluate findings
@@ -192,9 +203,9 @@ jobs:
           # from the local SARIF — that way dismissed alerts (e.g. false
           # positives, tests) are excluded from the PR gate and summary even
           # though CodeQL still re-detects them on every run.
-          # `analyze@v3` with `wait-for-processing: true` already blocks until
-          # GitHub has ingested the SARIF and matched dismissals, so we can
-          # query the API directly here without a manual sleep.
+          # The `Upload filtered SARIF` step (upload-sarif@v3) runs with
+          # `wait-for-processing: true` so GitHub has ingested the SARIF and
+          # matched dismissals by the time we query the API here.
 
           QUERY="state=open&tool_name=CodeQL&per_page=100"
           if [ "${EVENT_NAME}" = "pull_request" ] || [ "${EVENT_NAME}" = "pull_request_target" ]; then

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -251,7 +251,19 @@ jobs:
         with:
           category: nightly-sast
           output: ${{ inputs.working-directory }}/security-reports
-          upload: true
+          upload: never
+
+      - name: Filter generated-code findings from SARIF
+        uses: ./.github/actions-repo/.github/actions/security/filter-sarif
+        with:
+          sarif-dir: ${{ inputs.working-directory }}/security-reports
+
+      - name: Upload filtered SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ inputs.working-directory }}/security-reports
+          category: nightly-sast
+          wait-for-processing: true
 
       - name: Upload SAST report
         if: always()


### PR DESCRIPTION
## Summary
- CodeQL `paths-ignore` is a no-op for compiled languages (C#, Java, Go, Kotlin) — generated files (`obj/`, `bin/`, `*.g.cs`, `*.Designer.cs`, `*.AssemblyInfo.cs`) get extracted during the build and re-appear as alerts every run regardless.
- New `.github/actions/security/filter-sarif` composite action strips matching results from the SARIF after `analyze@v3` but before upload.
- Wired into both `job-codeql.yml` (PR) and `nightly-security.yml` (nightly). `analyze@v3` now uses `upload: never`; `wait-for-processing: true` moves to the new `upload-sarif@v3` step.
- Shared `codeql-config.yml` keeps `paths-ignore` as documented intent, with a note explaining where enforcement actually happens.

## Why
Notify dashboard had 3 open alerts (all in `obj/.g.cs`); Pulse had 94 (37 in `obj/`, mostly proto + source-generator output). All 40 are now dismissed manually as a one-time cleanup. This change prevents them from being recreated on the next nightly run.

## Test plan
- [ ] Next PR run on any consuming repo (Notify/Pulse) shows the new "Filter generated-code findings from SARIF" step in the CodeQL job log
- [ ] Step output reports `before → after` counts and the dropped delta lines up with the actual obj/bin paths
- [ ] No new alerts created in `obj/` paths after merge + nightly run
- [ ] PR gate (Evaluate findings) still respects dismissals via the Code Scanning API

🤖 Generated with [Claude Code](https://claude.com/claude-code)