### PR TITLE
feat(hive): add project metadata cache and app auth support

### DIFF
--- a/.github/config/hive-project-metadata.json
+++ b/.github/config/hive-project-metadata.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema_version": "1.0",
-    "last_refreshed_utc": "2026-05-02T12:13:01Z",
+    "last_refreshed_utc": "2026-05-02T12:24:13Z",
     "project_owner": "HoneyDrunkStudios",
     "project_number": 4,
     "refresh_workflow": ".github/workflows/refresh-hive-project-metadata.yml"
@@ -9,278 +9,281 @@
   "project": {
     "id": "PVT_kwDOCxPmns4BUMbi"
   },
-  "fields": [
-    {
-      "id": "PVTF_lADOCxPmns4BUMbizhBWQNM",
-      "name": "Title",
-      "type": "ProjectV2Field"
-    },
-    {
-      "id": "PVTF_lADOCxPmns4BUMbizhBWQNQ",
-      "name": "Assignees",
-      "type": "ProjectV2Field"
-    },
-    {
-      "id": "PVTSSF_lADOCxPmns4BUMbizhBWQNU",
-      "name": "Status",
-      "options": [
-        {
-          "id": "f75ad846",
-          "name": "Backlog"
-        },
-        {
-          "id": "7bddaab6",
-          "name": "Ready"
-        },
-        {
-          "id": "47fc9ee4",
-          "name": "In Progress"
-        },
-        {
-          "id": "9193871d",
-          "name": "In Progress - Agent"
-        },
-        {
-          "id": "98236657",
-          "name": "Done"
-        },
-        {
-          "id": "2b646205",
-          "name": "Blocked"
-        }
-      ],
-      "type": "ProjectV2SingleSelectField"
-    },
-    {
-      "id": "PVTF_lADOCxPmns4BUMbizhBWQNY",
-      "name": "Labels",
-      "type": "ProjectV2Field"
-    },
-    {
-      "id": "PVTF_lADOCxPmns4BUMbizhBWQNc",
-      "name": "Linked pull requests",
-      "type": "ProjectV2Field"
-    },
-    {
-      "id": "PVTF_lADOCxPmns4BUMbizhBWQNg",
-      "name": "Milestone",
-      "type": "ProjectV2Field"
-    },
-    {
-      "id": "PVTF_lADOCxPmns4BUMbizhBWQNk",
-      "name": "Repository",
-      "type": "ProjectV2Field"
-    },
-    {
-      "id": "PVTF_lADOCxPmns4BUMbizhBWQNs",
-      "name": "Reviewers",
-      "type": "ProjectV2Field"
-    },
-    {
-      "id": "PVTF_lADOCxPmns4BUMbizhBWQNw",
-      "name": "Parent issue",
-      "type": "ProjectV2Field"
-    },
-    {
-      "id": "PVTF_lADOCxPmns4BUMbizhBWQN0",
-      "name": "Sub-issues progress",
-      "type": "ProjectV2Field"
-    },
-    {
-      "id": "PVTSSF_lADOCxPmns4BUMbizhBWQ88",
-      "name": "Wave",
-      "options": [
-        {
-          "id": "cf93b1ff",
-          "name": "Wave 1"
-        },
-        {
-          "id": "6c855f03",
-          "name": "Wave 2"
-        },
-        {
-          "id": "08ef9f77",
-          "name": "Wave 3"
-        },
-        {
-          "id": "7f870acb",
-          "name": "N/A"
-        }
-      ],
-      "type": "ProjectV2SingleSelectField"
-    },
-    {
-      "id": "PVTSSF_lADOCxPmns4BUMbizhBWRTQ",
-      "name": "Initiative",
-      "options": [
-        {
-          "id": "4912648b",
-          "name": "adr-0005-0006-rollout"
-        },
-        {
-          "id": "25b89f58",
-          "name": "honeydrunk-lore-bringup"
-        },
-        {
-          "id": "ad1300ef",
-          "name": "adr-0009-package-scanning-rollout"
-        },
-        {
-          "id": "a2b61615",
-          "name": "standalone"
-        },
-        {
-          "id": "35ad711d",
-          "name": "adr-0010-observe-ai-routing-phase-1"
-        },
-        {
-          "id": "8e53c06a",
-          "name": "adr-0015-container-apps-rollout"
-        },
-        {
-          "id": "a6b15048",
-          "name": "adr-0011-code-review-pipeline"
-        },
-        {
-          "id": "b7b8ae4c",
-          "name": "adr-0012-grid-cicd-control-plane"
-        }
-      ],
-      "type": "ProjectV2SingleSelectField"
-    },
-    {
-      "id": "PVTSSF_lADOCxPmns4BUMbizhBWSTA",
-      "name": "Node",
-      "options": [
-        {
-          "id": "3d8a9b1e",
-          "name": "honeydrunk-kernel"
-        },
-        {
-          "id": "ab216194",
-          "name": "honeydrunk-transport"
-        },
-        {
-          "id": "41f8808e",
-          "name": "honeydrunk-vault"
-        },
-        {
-          "id": "a0556f9a",
-          "name": "honeydrunk-auth"
-        },
-        {
-          "id": "859ce664",
-          "name": "honeydrunk-web-rest"
-        },
-        {
-          "id": "1ff4dbfb",
-          "name": "honeydrunk-data"
-        },
-        {
-          "id": "c23f7a9b",
-          "name": "pulse"
-        },
-        {
-          "id": "7ce4d8ad",
-          "name": "honeydrunk-notify"
-        },
-        {
-          "id": "80f827e5",
-          "name": "honeydrunk-actions"
-        },
-        {
-          "id": "f9330322",
-          "name": "honeydrunk-architecture"
-        },
-        {
-          "id": "86ae7f5e",
-          "name": "honeydrunk-studios"
-        },
-        {
-          "id": "6239c7de",
-          "name": "honeydrunk-ai"
-        },
-        {
-          "id": "4a5f1359",
-          "name": "honeydrunk-capabilities"
-        },
-        {
-          "id": "ed58d574",
-          "name": "honeydrunk-agents"
-        },
-        {
-          "id": "bdf006d9",
-          "name": "honeydrunk-memory"
-        },
-        {
-          "id": "f0f854de",
-          "name": "honeydrunk-knowledge"
-        },
-        {
-          "id": "32133319",
-          "name": "honeydrunk-flow"
-        },
-        {
-          "id": "3c326960",
-          "name": "honeydrunk-operator"
-        },
-        {
-          "id": "bcc89b82",
-          "name": "honeydrunk-evals"
-        },
-        {
-          "id": "d97442dd",
-          "name": "honeydrunk-sim"
-        },
-        {
-          "id": "7b2cd20f",
-          "name": "honeydrunk-lore"
-        },
-        {
-          "id": "929b1a7f",
-          "name": "honeydrunk-standards"
-        }
-      ],
-      "type": "ProjectV2SingleSelectField"
-    },
-    {
-      "id": "PVTSSF_lADOCxPmns4BUMbizhBWS1w",
-      "name": "Tier",
-      "options": [
-        {
-          "id": "a3197d54",
-          "name": "1"
-        },
-        {
-          "id": "7f7b79fa",
-          "name": "2"
-        },
-        {
-          "id": "943833d9",
-          "name": "3"
-        }
-      ],
-      "type": "ProjectV2SingleSelectField"
-    },
-    {
-      "id": "PVTF_lADOCxPmns4BUMbizhBWS4U",
-      "name": "ADR",
-      "type": "ProjectV2Field"
-    },
-    {
-      "id": "PVTSSF_lADOCxPmns4BUMbizhBbxQE",
-      "name": "Actor",
-      "options": [
-        {
-          "id": "b32d157e",
-          "name": "Agent"
-        },
-        {
-          "id": "846468b6",
-          "name": "Human"
-        }
-      ],
-      "type": "ProjectV2SingleSelectField"
-    }
-  ]
+  "fields": {
+    "fields": [
+      {
+        "id": "PVTF_lADOCxPmns4BUMbizhBWQNM",
+        "name": "Title",
+        "type": "ProjectV2Field"
+      },
+      {
+        "id": "PVTF_lADOCxPmns4BUMbizhBWQNQ",
+        "name": "Assignees",
+        "type": "ProjectV2Field"
+      },
+      {
+        "id": "PVTSSF_lADOCxPmns4BUMbizhBWQNU",
+        "name": "Status",
+        "options": [
+          {
+            "id": "f75ad846",
+            "name": "Backlog"
+          },
+          {
+            "id": "7bddaab6",
+            "name": "Ready"
+          },
+          {
+            "id": "47fc9ee4",
+            "name": "In Progress"
+          },
+          {
+            "id": "9193871d",
+            "name": "In Progress - Agent"
+          },
+          {
+            "id": "98236657",
+            "name": "Done"
+          },
+          {
+            "id": "2b646205",
+            "name": "Blocked"
+          }
+        ],
+        "type": "ProjectV2SingleSelectField"
+      },
+      {
+        "id": "PVTF_lADOCxPmns4BUMbizhBWQNY",
+        "name": "Labels",
+        "type": "ProjectV2Field"
+      },
+      {
+        "id": "PVTF_lADOCxPmns4BUMbizhBWQNc",
+        "name": "Linked pull requests",
+        "type": "ProjectV2Field"
+      },
+      {
+        "id": "PVTF_lADOCxPmns4BUMbizhBWQNg",
+        "name": "Milestone",
+        "type": "ProjectV2Field"
+      },
+      {
+        "id": "PVTF_lADOCxPmns4BUMbizhBWQNk",
+        "name": "Repository",
+        "type": "ProjectV2Field"
+      },
+      {
+        "id": "PVTF_lADOCxPmns4BUMbizhBWQNs",
+        "name": "Reviewers",
+        "type": "ProjectV2Field"
+      },
+      {
+        "id": "PVTF_lADOCxPmns4BUMbizhBWQNw",
+        "name": "Parent issue",
+        "type": "ProjectV2Field"
+      },
+      {
+        "id": "PVTF_lADOCxPmns4BUMbizhBWQN0",
+        "name": "Sub-issues progress",
+        "type": "ProjectV2Field"
+      },
+      {
+        "id": "PVTSSF_lADOCxPmns4BUMbizhBWQ88",
+        "name": "Wave",
+        "options": [
+          {
+            "id": "cf93b1ff",
+            "name": "Wave 1"
+          },
+          {
+            "id": "6c855f03",
+            "name": "Wave 2"
+          },
+          {
+            "id": "08ef9f77",
+            "name": "Wave 3"
+          },
+          {
+            "id": "7f870acb",
+            "name": "N/A"
+          }
+        ],
+        "type": "ProjectV2SingleSelectField"
+      },
+      {
+        "id": "PVTSSF_lADOCxPmns4BUMbizhBWRTQ",
+        "name": "Initiative",
+        "options": [
+          {
+            "id": "4912648b",
+            "name": "adr-0005-0006-rollout"
+          },
+          {
+            "id": "25b89f58",
+            "name": "honeydrunk-lore-bringup"
+          },
+          {
+            "id": "ad1300ef",
+            "name": "adr-0009-package-scanning-rollout"
+          },
+          {
+            "id": "a2b61615",
+            "name": "standalone"
+          },
+          {
+            "id": "35ad711d",
+            "name": "adr-0010-observe-ai-routing-phase-1"
+          },
+          {
+            "id": "8e53c06a",
+            "name": "adr-0015-container-apps-rollout"
+          },
+          {
+            "id": "a6b15048",
+            "name": "adr-0011-code-review-pipeline"
+          },
+          {
+            "id": "b7b8ae4c",
+            "name": "adr-0012-grid-cicd-control-plane"
+          }
+        ],
+        "type": "ProjectV2SingleSelectField"
+      },
+      {
+        "id": "PVTSSF_lADOCxPmns4BUMbizhBWSTA",
+        "name": "Node",
+        "options": [
+          {
+            "id": "3d8a9b1e",
+            "name": "honeydrunk-kernel"
+          },
+          {
+            "id": "ab216194",
+            "name": "honeydrunk-transport"
+          },
+          {
+            "id": "41f8808e",
+            "name": "honeydrunk-vault"
+          },
+          {
+            "id": "a0556f9a",
+            "name": "honeydrunk-auth"
+          },
+          {
+            "id": "859ce664",
+            "name": "honeydrunk-web-rest"
+          },
+          {
+            "id": "1ff4dbfb",
+            "name": "honeydrunk-data"
+          },
+          {
+            "id": "c23f7a9b",
+            "name": "pulse"
+          },
+          {
+            "id": "7ce4d8ad",
+            "name": "honeydrunk-notify"
+          },
+          {
+            "id": "80f827e5",
+            "name": "honeydrunk-actions"
+          },
+          {
+            "id": "f9330322",
+            "name": "honeydrunk-architecture"
+          },
+          {
+            "id": "86ae7f5e",
+            "name": "honeydrunk-studios"
+          },
+          {
+            "id": "6239c7de",
+            "name": "honeydrunk-ai"
+          },
+          {
+            "id": "4a5f1359",
+            "name": "honeydrunk-capabilities"
+          },
+          {
+            "id": "ed58d574",
+            "name": "honeydrunk-agents"
+          },
+          {
+            "id": "bdf006d9",
+            "name": "honeydrunk-memory"
+          },
+          {
+            "id": "f0f854de",
+            "name": "honeydrunk-knowledge"
+          },
+          {
+            "id": "32133319",
+            "name": "honeydrunk-flow"
+          },
+          {
+            "id": "3c326960",
+            "name": "honeydrunk-operator"
+          },
+          {
+            "id": "bcc89b82",
+            "name": "honeydrunk-evals"
+          },
+          {
+            "id": "d97442dd",
+            "name": "honeydrunk-sim"
+          },
+          {
+            "id": "7b2cd20f",
+            "name": "honeydrunk-lore"
+          },
+          {
+            "id": "929b1a7f",
+            "name": "honeydrunk-standards"
+          }
+        ],
+        "type": "ProjectV2SingleSelectField"
+      },
+      {
+        "id": "PVTSSF_lADOCxPmns4BUMbizhBWS1w",
+        "name": "Tier",
+        "options": [
+          {
+            "id": "a3197d54",
+            "name": "1"
+          },
+          {
+            "id": "7f7b79fa",
+            "name": "2"
+          },
+          {
+            "id": "943833d9",
+            "name": "3"
+          }
+        ],
+        "type": "ProjectV2SingleSelectField"
+      },
+      {
+        "id": "PVTF_lADOCxPmns4BUMbizhBWS4U",
+        "name": "ADR",
+        "type": "ProjectV2Field"
+      },
+      {
+        "id": "PVTSSF_lADOCxPmns4BUMbizhBbxQE",
+        "name": "Actor",
+        "options": [
+          {
+            "id": "b32d157e",
+            "name": "Agent"
+          },
+          {
+            "id": "846468b6",
+            "name": "Human"
+          }
+        ],
+        "type": "ProjectV2SingleSelectField"
+      }
+    ],
+    "totalCount": 16
+  }
 }

--- a/.github/config/hive-project-metadata.json
+++ b/.github/config/hive-project-metadata.json
@@ -1,0 +1,286 @@
+{
+  "_meta": {
+    "schema_version": "1.0",
+    "last_refreshed_utc": "2026-05-02T12:13:01Z",
+    "project_owner": "HoneyDrunkStudios",
+    "project_number": 4,
+    "refresh_workflow": ".github/workflows/refresh-hive-project-metadata.yml"
+  },
+  "project": {
+    "id": "PVT_kwDOCxPmns4BUMbi"
+  },
+  "fields": [
+    {
+      "id": "PVTF_lADOCxPmns4BUMbizhBWQNM",
+      "name": "Title",
+      "type": "ProjectV2Field"
+    },
+    {
+      "id": "PVTF_lADOCxPmns4BUMbizhBWQNQ",
+      "name": "Assignees",
+      "type": "ProjectV2Field"
+    },
+    {
+      "id": "PVTSSF_lADOCxPmns4BUMbizhBWQNU",
+      "name": "Status",
+      "options": [
+        {
+          "id": "f75ad846",
+          "name": "Backlog"
+        },
+        {
+          "id": "7bddaab6",
+          "name": "Ready"
+        },
+        {
+          "id": "47fc9ee4",
+          "name": "In Progress"
+        },
+        {
+          "id": "9193871d",
+          "name": "In Progress - Agent"
+        },
+        {
+          "id": "98236657",
+          "name": "Done"
+        },
+        {
+          "id": "2b646205",
+          "name": "Blocked"
+        }
+      ],
+      "type": "ProjectV2SingleSelectField"
+    },
+    {
+      "id": "PVTF_lADOCxPmns4BUMbizhBWQNY",
+      "name": "Labels",
+      "type": "ProjectV2Field"
+    },
+    {
+      "id": "PVTF_lADOCxPmns4BUMbizhBWQNc",
+      "name": "Linked pull requests",
+      "type": "ProjectV2Field"
+    },
+    {
+      "id": "PVTF_lADOCxPmns4BUMbizhBWQNg",
+      "name": "Milestone",
+      "type": "ProjectV2Field"
+    },
+    {
+      "id": "PVTF_lADOCxPmns4BUMbizhBWQNk",
+      "name": "Repository",
+      "type": "ProjectV2Field"
+    },
+    {
+      "id": "PVTF_lADOCxPmns4BUMbizhBWQNs",
+      "name": "Reviewers",
+      "type": "ProjectV2Field"
+    },
+    {
+      "id": "PVTF_lADOCxPmns4BUMbizhBWQNw",
+      "name": "Parent issue",
+      "type": "ProjectV2Field"
+    },
+    {
+      "id": "PVTF_lADOCxPmns4BUMbizhBWQN0",
+      "name": "Sub-issues progress",
+      "type": "ProjectV2Field"
+    },
+    {
+      "id": "PVTSSF_lADOCxPmns4BUMbizhBWQ88",
+      "name": "Wave",
+      "options": [
+        {
+          "id": "cf93b1ff",
+          "name": "Wave 1"
+        },
+        {
+          "id": "6c855f03",
+          "name": "Wave 2"
+        },
+        {
+          "id": "08ef9f77",
+          "name": "Wave 3"
+        },
+        {
+          "id": "7f870acb",
+          "name": "N/A"
+        }
+      ],
+      "type": "ProjectV2SingleSelectField"
+    },
+    {
+      "id": "PVTSSF_lADOCxPmns4BUMbizhBWRTQ",
+      "name": "Initiative",
+      "options": [
+        {
+          "id": "4912648b",
+          "name": "adr-0005-0006-rollout"
+        },
+        {
+          "id": "25b89f58",
+          "name": "honeydrunk-lore-bringup"
+        },
+        {
+          "id": "ad1300ef",
+          "name": "adr-0009-package-scanning-rollout"
+        },
+        {
+          "id": "a2b61615",
+          "name": "standalone"
+        },
+        {
+          "id": "35ad711d",
+          "name": "adr-0010-observe-ai-routing-phase-1"
+        },
+        {
+          "id": "8e53c06a",
+          "name": "adr-0015-container-apps-rollout"
+        },
+        {
+          "id": "a6b15048",
+          "name": "adr-0011-code-review-pipeline"
+        },
+        {
+          "id": "b7b8ae4c",
+          "name": "adr-0012-grid-cicd-control-plane"
+        }
+      ],
+      "type": "ProjectV2SingleSelectField"
+    },
+    {
+      "id": "PVTSSF_lADOCxPmns4BUMbizhBWSTA",
+      "name": "Node",
+      "options": [
+        {
+          "id": "3d8a9b1e",
+          "name": "honeydrunk-kernel"
+        },
+        {
+          "id": "ab216194",
+          "name": "honeydrunk-transport"
+        },
+        {
+          "id": "41f8808e",
+          "name": "honeydrunk-vault"
+        },
+        {
+          "id": "a0556f9a",
+          "name": "honeydrunk-auth"
+        },
+        {
+          "id": "859ce664",
+          "name": "honeydrunk-web-rest"
+        },
+        {
+          "id": "1ff4dbfb",
+          "name": "honeydrunk-data"
+        },
+        {
+          "id": "c23f7a9b",
+          "name": "pulse"
+        },
+        {
+          "id": "7ce4d8ad",
+          "name": "honeydrunk-notify"
+        },
+        {
+          "id": "80f827e5",
+          "name": "honeydrunk-actions"
+        },
+        {
+          "id": "f9330322",
+          "name": "honeydrunk-architecture"
+        },
+        {
+          "id": "86ae7f5e",
+          "name": "honeydrunk-studios"
+        },
+        {
+          "id": "6239c7de",
+          "name": "honeydrunk-ai"
+        },
+        {
+          "id": "4a5f1359",
+          "name": "honeydrunk-capabilities"
+        },
+        {
+          "id": "ed58d574",
+          "name": "honeydrunk-agents"
+        },
+        {
+          "id": "bdf006d9",
+          "name": "honeydrunk-memory"
+        },
+        {
+          "id": "f0f854de",
+          "name": "honeydrunk-knowledge"
+        },
+        {
+          "id": "32133319",
+          "name": "honeydrunk-flow"
+        },
+        {
+          "id": "3c326960",
+          "name": "honeydrunk-operator"
+        },
+        {
+          "id": "bcc89b82",
+          "name": "honeydrunk-evals"
+        },
+        {
+          "id": "d97442dd",
+          "name": "honeydrunk-sim"
+        },
+        {
+          "id": "7b2cd20f",
+          "name": "honeydrunk-lore"
+        },
+        {
+          "id": "929b1a7f",
+          "name": "honeydrunk-standards"
+        }
+      ],
+      "type": "ProjectV2SingleSelectField"
+    },
+    {
+      "id": "PVTSSF_lADOCxPmns4BUMbizhBWS1w",
+      "name": "Tier",
+      "options": [
+        {
+          "id": "a3197d54",
+          "name": "1"
+        },
+        {
+          "id": "7f7b79fa",
+          "name": "2"
+        },
+        {
+          "id": "943833d9",
+          "name": "3"
+        }
+      ],
+      "type": "ProjectV2SingleSelectField"
+    },
+    {
+      "id": "PVTF_lADOCxPmns4BUMbizhBWS4U",
+      "name": "ADR",
+      "type": "ProjectV2Field"
+    },
+    {
+      "id": "PVTSSF_lADOCxPmns4BUMbizhBbxQE",
+      "name": "Actor",
+      "options": [
+        {
+          "id": "b32d157e",
+          "name": "Agent"
+        },
+        {
+          "id": "846468b6",
+          "name": "Human"
+        }
+      ],
+      "type": "ProjectV2SingleSelectField"
+    }
+  ]
+}

--- a/.github/workflows/hive-field-mirror.yml
+++ b/.github/workflows/hive-field-mirror.yml
@@ -116,6 +116,8 @@ jobs:
         id: load-cache
         env:
           CACHE_PATH: ./honeydrunk-actions/.github/config/hive-project-metadata.json
+          EXPECTED_PROJECT_OWNER: ${{ github.event_name == 'workflow_call' && inputs.project-owner || 'HoneyDrunkStudios' }}
+          EXPECTED_PROJECT_NUMBER: ${{ github.event_name == 'workflow_call' && inputs.project-number || 4 }}
         run: |
           set -euo pipefail
           if [[ ! -f "$CACHE_PATH" ]]; then
@@ -125,6 +127,17 @@ jobs:
           fi
           if ! jq -e '._meta.schema_version == "1.0"' "$CACHE_PATH" >/dev/null; then
             echo "::warning::Cache schema mismatch; falling back to live lookup."
+            echo "use-cache=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! jq -e --arg owner "$EXPECTED_PROJECT_OWNER" --argjson number "$EXPECTED_PROJECT_NUMBER" \
+            '._meta.project_owner == $owner and ._meta.project_number == $number' "$CACHE_PATH" >/dev/null; then
+            echo "::warning::Cache project does not match requested project ${EXPECTED_PROJECT_OWNER}/${EXPECTED_PROJECT_NUMBER}; falling back to live lookup."
+            echo "use-cache=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! jq -e '(.fields | type) == "object" and (.fields.fields | type) == "array"' "$CACHE_PATH" >/dev/null; then
+            echo "::warning::Cache fields shape is invalid; falling back to live lookup."
             echo "use-cache=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/hive-field-mirror.yml
+++ b/.github/workflows/hive-field-mirror.yml
@@ -26,10 +26,31 @@ on:
         default: ''
     secrets:
       hive-field-mirror-token:
-        description: Token with issues read + organization projects write scopes.
-        required: true
+        description: >-
+          PAT with issues:read on target repos and projects:write on The Hive.
+          Used when App auth is not configured. Required if neither app-id nor
+          app-private-key is provided.
+        required: false
       HIVE_FIELD_MIRROR_TOKEN:
         description: Legacy org/repo secret name accepted for direct workflow triggers.
+        required: false
+      app-id:
+        description: >-
+          GitHub App ID for the dedicated Hive App. When provided together with
+          app-private-key, the workflow mints an installation token via
+          actions/create-github-app-token and uses it for every subsequent gh
+          call. Falls back to hive-field-mirror-token when either is absent.
+        required: false
+      app-private-key:
+        description: >-
+          GitHub App private key (PEM contents) paired with app-id. See app-id
+          description for fallback semantics.
+        required: false
+      HIVE_APP_ID:
+        description: Legacy org/repo App ID secret name accepted for direct workflow triggers.
+        required: false
+      HIVE_APP_PRIVATE_KEY:
+        description: Legacy org/repo App private key secret name accepted for direct workflow triggers.
         required: false
 
 permissions:
@@ -40,6 +61,37 @@ jobs:
   mirror:
     runs-on: ubuntu-latest
     steps:
+      - name: Detect auth mode
+        # Workflow-level `if:` expressions cannot reference the `secrets`
+        # context, so we route the presence test through env vars and emit a
+        # step output the App-token step can gate on.
+        id: auth-mode
+        env:
+          APP_ID: ${{ secrets.app-id || secrets.HIVE_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.app-private-key || secrets.HIVE_APP_PRIVATE_KEY }}
+          PAT_FALLBACK: ${{ secrets.hive-field-mirror-token || secrets.HIVE_FIELD_MIRROR_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${APP_ID}" && -n "${APP_PRIVATE_KEY}" ]]; then
+            echo "use-app=true" >> "$GITHUB_OUTPUT"
+            echo "Auth path: GitHub App"
+          elif [[ -n "${PAT_FALLBACK}" ]]; then
+            echo "use-app=false" >> "$GITHUB_OUTPUT"
+            echo "Auth path: PAT fallback (hive-field-mirror-token)"
+          else
+            echo "::error::Neither GitHub App auth (app-id + app-private-key) nor hive-field-mirror-token PAT was provided"
+            exit 1
+          fi
+
+      - name: Mint GitHub App installation token
+        id: app-token
+        if: steps.auth-mode.outputs.use-app == 'true'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.app-id || secrets.HIVE_APP_ID }}
+          private-key: ${{ secrets.app-private-key || secrets.HIVE_APP_PRIVATE_KEY }}
+          owner: ${{ github.event_name == 'workflow_call' && inputs.project-owner || 'HoneyDrunkStudios' }}
+
       - name: Resolve actions checkout ref
         id: resolve-ref
         run: |
@@ -59,6 +111,43 @@ jobs:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           ref: ${{ steps.resolve-ref.outputs.ref }}
           path: honeydrunk-actions
+
+      - name: Load cached project metadata
+        id: load-cache
+        env:
+          CACHE_PATH: ./honeydrunk-actions/.github/config/hive-project-metadata.json
+        run: |
+          set -euo pipefail
+          if [[ ! -f "$CACHE_PATH" ]]; then
+            echo "::warning::Project metadata cache not found at $CACHE_PATH; falling back to live GraphQL lookup."
+            echo "use-cache=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! jq -e '._meta.schema_version == "1.0"' "$CACHE_PATH" >/dev/null; then
+            echo "::warning::Cache schema mismatch; falling back to live lookup."
+            echo "use-cache=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          LAST_REFRESH="$(jq -r '._meta.last_refreshed_utc // empty' "$CACHE_PATH")"
+          if ! REFRESH_EPOCH="$(date -u -d "$LAST_REFRESH" +%s 2>/dev/null)"; then
+            echo "::warning::Cache refresh timestamp is invalid; falling back to live lookup."
+            echo "use-cache=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          NOW_EPOCH="$(date -u +%s)"
+          AGE_DAYS=$(( (NOW_EPOCH - REFRESH_EPOCH) / 86400 ))
+          if (( AGE_DAYS > 14 )); then
+            echo "::warning::Cache is ${AGE_DAYS} days old (max 14); falling back to live lookup. Run refresh-hive-project-metadata.yml to fix."
+            echo "use-cache=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "HIVE_PROJECT_METADATA_JSON<<METADATA_EOF"
+            cat "$CACHE_PATH"
+            echo "METADATA_EOF"
+          } >> "$GITHUB_ENV"
+          echo "use-cache=true" >> "$GITHUB_OUTPUT"
+          echo "Loaded project metadata cache (age: ${AGE_DAYS} days)."
 
       - name: Resolve issue URL
         id: issue
@@ -81,7 +170,7 @@ jobs:
         env:
           PROJECT_OWNER: ${{ github.event_name == 'workflow_call' && inputs.project-owner || 'HoneyDrunkStudios' }}
           PROJECT_NUMBER: ${{ github.event_name == 'workflow_call' && inputs.project-number || 4 }}
-          HIVE_FIELD_MIRROR_TOKEN: ${{ secrets.hive-field-mirror-token || secrets.HIVE_FIELD_MIRROR_TOKEN }}
+          HIVE_FIELD_MIRROR_TOKEN: ${{ steps.app-token.outputs.token || secrets.hive-field-mirror-token || secrets.HIVE_FIELD_MIRROR_TOKEN }}
           ISSUE_URL: ${{ steps.issue.outputs.issue_url }}
         run: |
           set -euo pipefail
@@ -89,7 +178,7 @@ jobs:
             echo "HIVE_FIELD_MIRROR_TOKEN is not configured." >&2
             exit 1
           fi
-          # Token may come from workflow_call secret or repo/org secret fallback.
+          # Token may come from App auth, workflow_call secret, or repo/org secret fallback.
           ./honeydrunk-actions/scripts/hive-project-mirror.sh \
             --url "${ISSUE_URL}" \
             --project-owner "${PROJECT_OWNER}" \

--- a/.github/workflows/refresh-hive-project-metadata.yml
+++ b/.github/workflows/refresh-hive-project-metadata.yml
@@ -1,0 +1,92 @@
+name: Refresh Hive Project Metadata Cache
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: refresh-hive-project-metadata
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect auth mode
+        id: auth-mode
+        env:
+          APP_ID: ${{ secrets.HIVE_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.HIVE_APP_PRIVATE_KEY }}
+          PAT_FALLBACK: ${{ secrets.HIVE_FIELD_MIRROR_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${APP_ID}" && -n "${APP_PRIVATE_KEY}" ]]; then
+            echo "use-app=true" >> "$GITHUB_OUTPUT"
+            echo "Auth path: GitHub App"
+          elif [[ -n "${PAT_FALLBACK}" ]]; then
+            echo "use-app=false" >> "$GITHUB_OUTPUT"
+            echo "Auth path: PAT fallback (hive-field-mirror-token)"
+          else
+            echo "::error::Neither GitHub App auth (HIVE_APP_ID + HIVE_APP_PRIVATE_KEY) nor HIVE_FIELD_MIRROR_TOKEN PAT was provided"
+            exit 1
+          fi
+
+      - name: Mint GitHub App installation token
+        id: app-token
+        if: steps.auth-mode.outputs.use-app == 'true'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.HIVE_APP_ID }}
+          private-key: ${{ secrets.HIVE_APP_PRIVATE_KEY }}
+          owner: HoneyDrunkStudios
+
+      - name: Refresh metadata cache
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.HIVE_FIELD_MIRROR_TOKEN }}
+          PROJECT_OWNER: HoneyDrunkStudios
+          PROJECT_NUMBER: 4
+          CACHE_PATH: .github/config/hive-project-metadata.json
+        run: |
+          set -euo pipefail
+          PROJECT_JSON="$(gh project view "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json)"
+          FIELDS_JSON="$(gh project field-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json)"
+          NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          jq -n \
+            --arg now "$NOW" \
+            --arg owner "$PROJECT_OWNER" \
+            --argjson number "$PROJECT_NUMBER" \
+            --argjson project "$PROJECT_JSON" \
+            --argjson fields "$FIELDS_JSON" \
+            '{
+              _meta: {
+                schema_version: "1.0",
+                last_refreshed_utc: $now,
+                project_owner: $owner,
+                project_number: $number,
+                refresh_workflow: ".github/workflows/refresh-hive-project-metadata.yml"
+              },
+              project: { id: $project.id },
+              fields: $fields.fields
+            }' > "$CACHE_PATH"
+
+      - name: Commit cache update
+        env:
+          CACHE_PATH: .github/config/hive-project-metadata.json
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- "$CACHE_PATH"; then
+            echo "Cache unchanged."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- "$CACHE_PATH"
+          git commit -m "chore(hive): refresh project metadata cache [skip ci]"
+          git push

--- a/.github/workflows/refresh-hive-project-metadata.yml
+++ b/.github/workflows/refresh-hive-project-metadata.yml
@@ -73,7 +73,7 @@ jobs:
                 refresh_workflow: ".github/workflows/refresh-hive-project-metadata.yml"
               },
               project: { id: $project.id },
-              fields: $fields.fields
+              fields: $fields
             }' > "$CACHE_PATH"
 
       - name: Commit cache update

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -136,6 +136,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Consolidated report: automated finding counts from all SARIF/JSON artifacts
   - GitHub issue creation: auto-create or update issues labeled `security,automated`
   - Rich GitHub Step Summary with scanner breakdown table
+- Refresh Hive project metadata workflow (`refresh-hive-project-metadata.yml`) for weekly and manual cache refresh.
+- Hive project metadata cache (`.github/config/hive-project-metadata.json`) for stable project, field, and option IDs.
+
+### Changed
+- `hive-field-mirror.yml`: accept `app-id` and `app-private-key` for GitHub App auth; PAT auth remains available as a fallback.
+- `hive-field-mirror.yml`: load cached Hive project metadata before per-issue mirror runs, falling back to live GraphQL lookup when the cache is absent, invalid, or stale.
 
 ### Planned
 - Integration with SonarQube

--- a/scripts/hive-project-mirror.sh
+++ b/scripts/hive-project-mirror.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Projects v2 is GraphQL-only; the legacy REST Projects API was sunset in
+# 2022. Field updates, item adds, and option ensures cannot be moved off
+# GraphQL. Issue labels are already read from the REST issue payload; this
+# script does not write labels. To reduce per-invocation GraphQL cost, this
+# script reads the project, field, and option metadata from a cached JSON blob
+# via the HIVE_PROJECT_METADATA_JSON env var when set. The cache is refreshed
+# weekly by .github/workflows/refresh-hive-project-metadata.yml. When the env
+# var is absent, the script live-fetches via gh project view and gh project
+# field-list for standalone CLI compatibility.
+
 PROJECT_OWNER="HoneyDrunkStudios"
 PROJECT_NUMBER="4"
 ISSUE_URL=""
@@ -168,7 +178,7 @@ if [[ -z "$PROJECT_ID" || "$PROJECT_ID" == "null" ]]; then
   exit 1
 fi
 
-add_item_query='mutation($project:ID!, $content:ID!) { addProjectV2ItemById(input:{projectId:$project, contentId:$content}) { item { id } } }'
+add_item_query="mutation(\$project:ID!, \$content:ID!) { addProjectV2ItemById(input:{projectId:\$project, contentId:\$content}) { item { id } } }"
 
 ITEM_ID=""
 set +e
@@ -183,7 +193,7 @@ else
 fi
 
 if [[ -z "$ITEM_ID" ]]; then
-  lookup_query='query($issue: ID!) { node(id: $issue) { ... on Issue { projectItems(first: 100) { nodes { id project { id } } } } } }'
+  lookup_query="query(\$issue: ID!) { node(id: \$issue) { ... on Issue { projectItems(first: 100) { nodes { id project { id } } } } } }"
   LOOKUP_JSON="$(gh api graphql -f query="$lookup_query" -f issue="$ISSUE_NODE_ID")"
   ITEM_ID="$(jq -r --arg project_id "$PROJECT_ID" '.data.node.projectItems.nodes[] | select(.project.id == $project_id) | .id' <<<"$LOOKUP_JSON" | head -n1)"
 fi
@@ -232,7 +242,7 @@ ensure_single_select_option() {
   local option_name="$2"
   local existing
   if ! existing="$(gh api graphql \
-    -f query='query($p:ID!,$f:String!){node(id:$p){... on ProjectV2{field(name:$f){... on ProjectV2SingleSelectField{id options{id name color description}}}}}}' \
+    -f query="query(\$p:ID!,\$f:String!){node(id:\$p){... on ProjectV2{field(name:\$f){... on ProjectV2SingleSelectField{id options{id name color description}}}}}}" \
     -f p="$PROJECT_ID" -f f="$field_name" 2>&1)"; then
     echo "ensure_single_select_option: query failed for field '$field_name': $existing" >&2
     return 1
@@ -279,7 +289,7 @@ update_single_select() {
     echo "::warning::Skipping ${label}; missing field/option id"
     return 0
   fi
-  local query='mutation($project:ID!, $item:ID!, $field:ID!, $option:String!) { updateProjectV2ItemFieldValue(input:{projectId:$project,itemId:$item,fieldId:$field,value:{singleSelectOptionId:$option}}) { projectV2Item { id } } }'
+  local query="mutation(\$project:ID!, \$item:ID!, \$field:ID!, \$option:String!) { updateProjectV2ItemFieldValue(input:{projectId:\$project,itemId:\$item,fieldId:\$field,value:{singleSelectOptionId:\$option}}) { projectV2Item { id } } }"
   gh_retry api graphql -f query="$query" -f project="$PROJECT_ID" -f item="$ITEM_ID" -f field="$field_id" -f option="$option_id" >/dev/null
 }
 
@@ -291,7 +301,7 @@ update_text() {
     echo "::warning::Skipping ${label}; missing field id"
     return 0
   fi
-  local query='mutation($project:ID!, $item:ID!, $field:ID!, $text:String!) { updateProjectV2ItemFieldValue(input:{projectId:$project,itemId:$item,fieldId:$field,value:{text:$text}}) { projectV2Item { id } } }'
+  local query="mutation(\$project:ID!, \$item:ID!, \$field:ID!, \$text:String!) { updateProjectV2ItemFieldValue(input:{projectId:\$project,itemId:\$item,fieldId:\$field,value:{text:\$text}}) { projectV2Item { id } } }"
   gh_retry api graphql -f query="$query" -f project="$PROJECT_ID" -f item="$ITEM_ID" -f field="$field_id" -f text="$text" >/dev/null
 }
 


### PR DESCRIPTION
introduce refresh-hive-project-metadata.yml for scheduled cache updates, add .github/config/hive-project-metadata.json for stable project/field/option IDs, enable GitHub App auth in hive-field-mirror.yml, and use cached metadata to reduce live GraphQL calls