### PR TITLE
fix: quiet hive node mapping warnings

### DIFF
--- a/.github/config/repo-to-node.yml
+++ b/.github/config/repo-to-node.yml
@@ -7,8 +7,10 @@ HoneyDrunk.Web.Rest: honeydrunk-web-rest
 HoneyDrunk.Data: honeydrunk-data
 HoneyDrunk.Pulse: pulse
 HoneyDrunk.Notify: honeydrunk-notify
+HoneyDrunk.Communications: honeydrunk-communications
 HoneyDrunk.Actions: honeydrunk-actions
 HoneyDrunk.Architecture: honeydrunk-architecture
+HoneyDrunk.Standards: honeydrunk-standards
 HoneyDrunkStudios: honeydrunk-studios
 HoneyDrunk.Lore: honeydrunk-lore
 HoneyDrunk.Agents: honeydrunk-agents

--- a/scripts/hive-project-mirror.sh
+++ b/scripts/hive-project-mirror.sh
@@ -331,7 +331,15 @@ fi
 
 if [[ -n "$NODE_OPTION" ]]; then
   NODE_OPTION_ID="$(get_single_option_id 'Node' "$NODE_OPTION")"
-  update_single_select "$NODE_FIELD_ID" "$NODE_OPTION_ID" 'Node'
+  if [[ -z "$NODE_OPTION_ID" ]]; then
+    echo "Auto-creating Node option: ${NODE_OPTION}"
+    NODE_OPTION_ID="$(ensure_single_select_option 'Node' "$NODE_OPTION")"
+  fi
+  if [[ -n "$NODE_OPTION_ID" ]]; then
+    update_single_select "$NODE_FIELD_ID" "$NODE_OPTION_ID" 'Node'
+  else
+    echo "::warning::Failed to resolve or create Node option: ${NODE_OPTION}"
+  fi
 else
   echo "::warning::No node mapping found for repository ${ISSUE_REPO}"
 fi


### PR DESCRIPTION
## Summary

Fixes noisy Hive field mirror warnings during packet filing:

- Adds repo-to-node mappings for `HoneyDrunk.Communications` and `HoneyDrunk.Standards`.
- Auto-creates missing Node field options when a mapped repo has no existing Project option, matching the existing Initiative option behavior.
- This should quiet the `No node mapping found` warnings for Communications/Standards and the `Skipping Node; missing field/option id` warning for mapped repos such as Vault.Rotation.

## Validation

- `python tmp_validate_mapping.py` before cleanup: confirmed Communications, Standards, and Vault.Rotation mappings are present.
- `C:\Program Files\Git\bin\bash.exe -n scripts/hive-project-mirror.sh scripts/file-packets.sh`
- `git diff --check`

## Notes

The remaining `target repo ... does not exist (or no access)` messages for Builds/Pipelines are separate: those target repos are not currently reachable by the filing token, so mapping changes alone cannot fix them.