### PR TITLE
fix: harden coverage summary and ratchet writes

### DIFF
--- a/.github/workflows/pr-core.yml
+++ b/.github/workflows/pr-core.yml
@@ -679,8 +679,10 @@ jobs:
       
       - name: Write summary to GitHub
         shell: bash
+        env:
+          SUMMARY_TEXT: ${{ steps.message.outputs.text }}
         run: |
-          echo "${{ steps.message.outputs.text }}" >> $GITHUB_STEP_SUMMARY
+          printf "%s\n" "$SUMMARY_TEXT" >> "$GITHUB_STEP_SUMMARY"
       
       - name: Post PR comment
         if: ${{ inputs.post-pr-summary }}
@@ -769,7 +771,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "${WORKING_DIRECTORY%/}/.github/coverage-baseline.json"
+          git add -f "${WORKING_DIRECTORY%/}/.github/coverage-baseline.json"
           if git diff --cached --quiet; then
             echo "Coverage baseline unchanged; nothing to commit."
             exit 0


### PR DESCRIPTION
## Summary

- Writes PR summary markdown through an environment variable with printf so markdown backticks are not executed by bash.
- Forces staging of coverage baseline JSON during ratchet so repo-wide coverage*.json ignore rules do not break baseline commits.

## Validation

- Root cause verified from Kernel run 26100667268: summary text with package backticks was shell-expanded during the GitHub summary write.
- Root cause verified from Kernel run 26098350164: baseline ratchet failed because coverage-baseline.json matched coverage*.json ignore rules.
