### PR TITLE
Fix coverage gates for multiple Cobertura reports

### DIFF
--- a/.github/actions/pr/generate-summary/action.yml
+++ b/.github/actions/pr/generate-summary/action.yml
@@ -70,6 +70,8 @@ runs:
       id: coverage
       if: ${{ inputs.include-coverage == 'true' }}
       shell: bash
+      env:
+        TEST_RESULTS_DIRECTORY: ${{ inputs.test-results-directory }}
       run: |
         set -euo pipefail
         
@@ -77,9 +79,33 @@ runs:
         COVERAGE="N/A"
         if [ -d "${{ inputs.test-results-directory }}" ]; then
           COVERAGE=$(python3 <<'PY'
-        import xml.etree.ElementTree as ET
+        import os, xml.etree.ElementTree as ET
         from pathlib import Path
-        root_dir = Path('${{ inputs.test-results-directory }}')
+        root_dir = Path(os.environ.get('TEST_RESULTS_DIRECTORY') or 'TestResults')
+        workdir = Path.cwd().resolve()
+
+        def is_test_or_canary(filename):
+            normalized = filename.replace('\\', '/')
+            return '.Tests' in normalized or '.Canary' in normalized
+
+        def canonical_source_key(filename):
+            path = Path(filename)
+            candidates = [path]
+            if not path.is_absolute():
+                candidates.append((workdir / path).resolve())
+                candidates.append(Path(path.as_posix().lstrip('/')).resolve())
+            for candidate in candidates:
+                try:
+                    resolved = candidate.resolve()
+                except OSError:
+                    continue
+                if resolved.exists():
+                    try:
+                        return str(resolved.relative_to(workdir)).replace('\\', '/').lower()
+                    except ValueError:
+                        return str(resolved).replace('\\', '/').lower()
+            return path.as_posix().lstrip('/').lower()
+
         line_hits = {}
         for cov in root_dir.rglob('coverage.cobertura.xml'):
             try:
@@ -88,9 +114,9 @@ runs:
                 continue
             for cls in root.findall('.//class'):
                 filename = cls.attrib.get('filename') or ''
-                if not filename or '.Tests' in filename or '.Canary' in filename:
+                if not filename or is_test_or_canary(filename):
                     continue
-                key = filename.replace('\\', '/').lower()
+                key = canonical_source_key(filename)
                 for line in cls.findall('.//line'):
                     try:
                         num = int(line.attrib.get('number', '0'))

--- a/.github/actions/pr/generate-summary/action.yml
+++ b/.github/actions/pr/generate-summary/action.yml
@@ -73,18 +73,39 @@ runs:
       run: |
         set -euo pipefail
         
-        # Parse coverage from Cobertura XML
+        # Parse and merge coverage from all Cobertura XML reports.
         COVERAGE="N/A"
         if [ -d "${{ inputs.test-results-directory }}" ]; then
-          COV_FILE=$(find "${{ inputs.test-results-directory }}" -type f -name "coverage.cobertura.xml" | head -n 1)
-          if [ -n "$COV_FILE" ] && [ -f "$COV_FILE" ]; then
-            # Extract line-rate (should be between 0 and 1)
-            LINE_RATE=$(grep -o 'line-rate="[0-9.]*"' "$COV_FILE" | head -n1 | grep -o '[0-9.]*' || echo "")
-            if [ -n "$LINE_RATE" ] && [ "$LINE_RATE" != "0" ]; then
-              # Validate it's a valid decimal and convert to percentage
-              COVERAGE=$(awk "BEGIN {rate=$LINE_RATE; if (rate >= 0 && rate <= 1) printf \"%.1f\", rate * 100; else print \"N/A\"}")
-            fi
-          fi
+          COVERAGE=$(python3 <<'PY'
+        import xml.etree.ElementTree as ET
+        from pathlib import Path
+        root_dir = Path('${{ inputs.test-results-directory }}')
+        line_hits = {}
+        for cov in root_dir.rglob('coverage.cobertura.xml'):
+            try:
+                root = ET.parse(cov).getroot()
+            except Exception:
+                continue
+            for cls in root.findall('.//class'):
+                filename = cls.attrib.get('filename') or ''
+                if not filename or '.Tests' in filename or '.Canary' in filename:
+                    continue
+                key = filename.replace('\\', '/').lower()
+                for line in cls.findall('.//line'):
+                    try:
+                        num = int(line.attrib.get('number', '0'))
+                        hits = int(line.attrib.get('hits', '0'))
+                    except ValueError:
+                        continue
+                    line_hits.setdefault(key, {})[num] = max(line_hits.setdefault(key, {}).get(num, 0), hits)
+        total = sum(len(lines) for lines in line_hits.values())
+        if not total:
+            print('N/A')
+        else:
+            covered = sum(1 for lines in line_hits.values() for hits in lines.values() if hits > 0)
+            print(f'{covered / total * 100:.1f}')
+        PY
+        )
         fi
         echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
     

--- a/.github/workflows/coverage-baseline-ratchet.yml
+++ b/.github/workflows/coverage-baseline-ratchet.yml
@@ -108,6 +108,29 @@ jobs:
           from datetime import datetime, timezone
           from pathlib import Path
           workdir = Path(os.environ.get('WORKING_DIRECTORY') or '.').resolve()
+
+          def is_test_or_canary(filename):
+              normalized = filename.replace('\\', '/')
+              return '.Tests' in normalized or '.Canary' in normalized
+
+          def canonical_source_key(filename):
+              path = Path(filename)
+              candidates = [path]
+              if not path.is_absolute():
+                  candidates.append((workdir / path).resolve())
+                  candidates.append(Path(path.as_posix().lstrip('/')).resolve())
+              for candidate in candidates:
+                  try:
+                      resolved = candidate.resolve()
+                  except OSError:
+                      continue
+                  if resolved.exists():
+                      try:
+                          return str(resolved.relative_to(workdir)).replace('\\', '/').lower()
+                      except ValueError:
+                          return str(resolved).replace('\\', '/').lower()
+              return path.as_posix().lstrip('/').lower()
+
           test_projects = [p for p in workdir.rglob('*.csproj') if p.name.endswith('.Tests.csproj') or p.name.endswith('.Canary.csproj')]
           cov_files = list(Path('TestResults').rglob('coverage.cobertura.xml'))
           if not test_projects or not cov_files:
@@ -123,9 +146,9 @@ jobs:
                   filename = cls.attrib.get('filename') or ''
                   if not filename:
                       continue
-                  if '.Tests' in filename or '.Canary' in filename:
+                  if is_test_or_canary(filename):
                       continue
-                  key = filename.replace('\\', '/').lower()
+                  key = canonical_source_key(filename)
                   for line in cls.findall('.//line'):
                       try:
                           num = int(line.attrib.get('number', '0'))

--- a/.github/workflows/coverage-baseline-ratchet.yml
+++ b/.github/workflows/coverage-baseline-ratchet.yml
@@ -113,17 +113,32 @@ jobs:
           if not test_projects or not cov_files:
               print('No test projects or coverage report found; skipping baseline ratchet.')
               sys.exit(0)
-          rate = None
+          line_hits = {}
           for cov in cov_files:
               try:
                   root = ET.parse(cov).getroot()
-                  rate = float(root.attrib.get('line-rate', '0')) * 100
-                  break
               except Exception:
                   continue
-          if rate is None:
-              print('No readable coverage report found; skipping baseline ratchet.')
+              for cls in root.findall('.//class'):
+                  filename = cls.attrib.get('filename') or ''
+                  if not filename:
+                      continue
+                  if '.Tests' in filename or '.Canary' in filename:
+                      continue
+                  key = filename.replace('\\', '/').lower()
+                  for line in cls.findall('.//line'):
+                      try:
+                          num = int(line.attrib.get('number', '0'))
+                          hits = int(line.attrib.get('hits', '0'))
+                      except ValueError:
+                          continue
+                      line_hits.setdefault(key, {})[num] = max(line_hits.setdefault(key, {}).get(num, 0), hits)
+          total_valid = sum(len(lines) for lines in line_hits.values())
+          if not total_valid:
+              print('No readable coverage lines found; skipping baseline ratchet.')
               sys.exit(0)
+          total_covered = sum(1 for lines in line_hits.values() for hits in lines.values() if hits > 0)
+          rate = total_covered / total_valid * 100
           target = workdir / '.github' / 'coverage-baseline.json'
           target.parent.mkdir(parents=True, exist_ok=True)
           new_total = round(rate, 2)

--- a/.github/workflows/pr-core.yml
+++ b/.github/workflows/pr-core.yml
@@ -320,19 +320,14 @@ jobs:
           test_projects = [p for p in workdir.rglob('*.csproj') if p.name.endswith('.Tests.csproj') or p.name.endswith('.Canary.csproj')]
           coverage_files = list(Path('TestResults').rglob('coverage.cobertura.xml'))
           line_hits = {}
+          total_line_hits = {}
           covered_assemblies = set()
-          total_rate = None
 
           for cov in coverage_files:
               try:
                   root = ET.parse(cov).getroot()
               except ET.ParseError:
                   continue
-              if total_rate is None:
-                  try:
-                      total_rate = float(root.attrib.get('line-rate', '0')) * 100
-                  except ValueError:
-                      total_rate = 0.0
               for cls in root.findall('.//class'):
                   filename = cls.attrib.get('filename') or ''
                   if not filename:
@@ -353,6 +348,8 @@ jobs:
                           continue
                       for key in normalized:
                           line_hits.setdefault(key, {})[num] = max(line_hits.setdefault(key, {}).get(num, 0), hits)
+                      canonical = str(path).replace('\\', '/').lower()
+                      total_line_hits.setdefault(canonical, {})[num] = max(total_line_hits.setdefault(canonical, {}).get(num, 0), hits)
 
           if not test_projects and not covered_assemblies:
               verdict = 'skipped (no test projects)'
@@ -361,8 +358,9 @@ jobs:
               emit('summary_line', 'Coverage gate: skipped (no test projects)')
               sys.exit(0)
 
-          if total_rate is None:
-              total_rate = 0.0
+          total_valid = sum(len(lines) for lines in total_line_hits.values())
+          total_covered = sum(1 for lines in total_line_hits.values() for hits in lines.values() if hits > 0)
+          total_rate = (total_covered / total_valid * 100) if total_valid else 0.0
 
           patch_coverable = 0
           patch_covered = 0

--- a/.github/workflows/pr-core.yml
+++ b/.github/workflows/pr-core.yml
@@ -317,6 +317,28 @@ jobs:
           def pct(v):
               return f"{v:.1f}".rstrip('0').rstrip('.')
 
+          def is_test_or_canary(filename):
+              normalized = filename.replace('\\', '/')
+              return '.Tests' in normalized or '.Canary' in normalized
+
+          def canonical_source_key(filename):
+              path = Path(filename)
+              candidates = [path]
+              if not path.is_absolute():
+                  candidates.append((workdir / path).resolve())
+                  candidates.append(Path(path.as_posix().lstrip('/')).resolve())
+              for candidate in candidates:
+                  try:
+                      resolved = candidate.resolve()
+                  except OSError:
+                      continue
+                  if resolved.exists():
+                      try:
+                          return str(resolved.relative_to(workdir)).replace('\\', '/').lower()
+                      except ValueError:
+                          return str(resolved).replace('\\', '/').lower()
+              return path.as_posix().lstrip('/').lower()
+
           test_projects = [p for p in workdir.rglob('*.csproj') if p.name.endswith('.Tests.csproj') or p.name.endswith('.Canary.csproj')]
           coverage_files = list(Path('TestResults').rglob('coverage.cobertura.xml'))
           line_hits = {}
@@ -332,7 +354,8 @@ jobs:
                   filename = cls.attrib.get('filename') or ''
                   if not filename:
                       continue
-                  if '.Tests' not in filename and '.Canary' not in filename:
+                  include_in_total = not is_test_or_canary(filename)
+                  if include_in_total:
                       covered_assemblies.add(filename)
                   path = Path(filename)
                   candidates = [path]
@@ -348,8 +371,9 @@ jobs:
                           continue
                       for key in normalized:
                           line_hits.setdefault(key, {})[num] = max(line_hits.setdefault(key, {}).get(num, 0), hits)
-                      canonical = str(path).replace('\\', '/').lower()
-                      total_line_hits.setdefault(canonical, {})[num] = max(total_line_hits.setdefault(canonical, {}).get(num, 0), hits)
+                      if include_in_total:
+                          canonical = canonical_source_key(filename)
+                          total_line_hits.setdefault(canonical, {})[num] = max(total_line_hits.setdefault(canonical, {}).get(num, 0), hits)
 
           if not test_projects and not covered_assemblies:
               verdict = 'skipped (no test projects)'


### PR DESCRIPTION
## Summary
- merge line hits across all Cobertura reports before evaluating PR coverage gates
- use the same merged coverage calculation for baseline ratcheting
- render merged coverage in PR summaries instead of whichever report appears first

## Validation
- parsed the failing Notify PR #18 coverage artifact locally and verified merged coverage resolves to 70.30% instead of the first-file 24.9%
- validated edited workflow/action YAML with PyYAML
- ran git diff --check

## Context
HoneyDrunk.Notify PR #18 now emits both unit and integration Cobertura reports. The reusable Actions gate was taking the first report from artifact extraction order, so it failed on the lower integration-only report even though merged coverage is above the 70% floor.