### PR TITLE
fix: clamp GitHub label names to 50 chars in file-packets

### DIFF
--- a/scripts/file-packets.sh
+++ b/scripts/file-packets.sh
@@ -348,6 +348,12 @@ repo_exists() {
 declare -A LABELS_LISTED=()
 declare -A LABELS_KNOWN=()
 
+# GitHub caps label names at 50 characters; a longer name fails label
+# creation with HTTP 422. Labels are clamped to this length before use
+# (see the packet loop) so an over-long initiative slug degrades to a
+# truncated label instead of aborting the whole run.
+GITHUB_LABEL_MAX=50
+
 ensure_label() {
   local repo="$1" name="$2"
   if [[ -z "${LABELS_LISTED[$repo]:-}" ]]; then
@@ -462,6 +468,10 @@ for packet in "$PACKETS_DIR_ABS"/**/*.md; do
   label_args=()
   for l in "${all_labels[@]}"; do
     [[ -z "$l" ]] && continue
+    if (( ${#l} > GITHUB_LABEL_MAX )); then
+      echo "::warning::Label '${l}' (${#l} chars) exceeds GitHub's ${GITHUB_LABEL_MAX}-char limit; truncating. Shorten the initiative slug for ${rel}."
+      l="${l:0:GITHUB_LABEL_MAX}"
+    fi
     ensure_label "$target_repo" "$l"
     label_args+=("--label" "$l")
   done

--- a/scripts/file-packets.sh
+++ b/scripts/file-packets.sh
@@ -469,7 +469,10 @@ for packet in "$PACKETS_DIR_ABS"/**/*.md; do
   for l in "${all_labels[@]}"; do
     [[ -z "$l" ]] && continue
     if (( ${#l} > GITHUB_LABEL_MAX )); then
-      echo "::warning::Label '${l}' (${#l} chars) exceeds GitHub's ${GITHUB_LABEL_MAX}-char limit; truncating. Shorten the initiative slug for ${rel}."
+      # Plain echo, not ::warning:: — interpolating packet-derived values
+      # into a workflow command is an injection vector, same reason the
+      # skip-log lines above avoid workflow commands.
+      echo "warning: label '${l}' (${#l} chars) exceeds GitHub's ${GITHUB_LABEL_MAX}-char limit; truncating. Shorten the initiative slug for ${rel}."
       l="${l:0:GITHUB_LABEL_MAX}"
     fi
     ensure_label "$target_repo" "$l"


### PR DESCRIPTION
## Summary
A GitHub label name longer than **50 characters** fails creation with `HTTP 422: name is too long`. Because `file-packets.sh` runs under `set -euo pipefail`, that failure **aborts the whole filing run** — every packet after the offending one goes unfiled.

This happened on 2026-05-22: an over-long initiative slug produced the 54-char label `initiative-adr-0036-disaster-recovery-and-backup-policy`, and the run died before filing ADR-0036's packets.

## Change
`scripts/file-packets.sh` — clamp every label to 50 chars in the packet loop before `ensure_label` / `--label` use, and emit a `::warning::` annotation naming the packet so the operator can shorten the initiative slug. A long slug now degrades to a truncated label instead of blocking the run.

This is defense-in-depth: the authoring-side fix is short initiative slugs, but the pipeline should never abort a whole batch over one long label.

## Test plan
- [ ] `bash -n scripts/file-packets.sh` passes (verified locally)
- [ ] A packet with a >50-char synthesized label files successfully with a truncated label + a workflow warning, instead of aborting the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)