### PR TITLE
fix(adr-0044): repair label fanout defaults

### DIFF
--- a/.github/config/labels.json
+++ b/.github/config/labels.json
@@ -13,7 +13,7 @@
     {
       "name": "out-of-band",
       "color": "ed7d31",
-      "description": "PR was not authored from a scope-agent packet; review agent runs without packet-scope context (per ADR-0011 D9, invariant 32)."
+      "description": "Out-of-band PR without packet scope context; review runs with reduced scope."
     },
     {
       "name": "skip-review",

--- a/.github/workflows/seed-labels-fanout.yml
+++ b/.github/workflows/seed-labels-fanout.yml
@@ -27,7 +27,7 @@ on:
         required: false
         type: string
         default: >-
-          HoneyDrunk.Kernel,HoneyDrunk.Transport,HoneyDrunk.Vault,HoneyDrunk.Auth,HoneyDrunk.Web.Rest,HoneyDrunk.Data,HoneyDrunk.Notify,HoneyDrunk.Communications,HoneyDrunk.Pulse,HoneyDrunk.Actions,HoneyDrunk.Architecture,HoneyDrunk.Studios
+          HoneyDrunk.Kernel,HoneyDrunk.Transport,HoneyDrunk.Vault,HoneyDrunk.Auth,HoneyDrunk.Web.Rest,HoneyDrunk.Data,HoneyDrunk.Notify,HoneyDrunk.Communications,HoneyDrunk.Pulse,HoneyDrunk.Actions,HoneyDrunk.Architecture,HoneyDrunkStudios
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Shorten the `out-of-band` label description to stay under GitHub's 100-character label-description limit.
- Replace the stale `HoneyDrunk.Studios` fan-out target with the actual org/defaults repo `HoneyDrunkStudios`.

## Validation

- `python` JSON parse of `.github/config/labels.json`
- `git diff --check`
- Manual rerun before this PR confirmed `LABELS_FANOUT_PAT` is now populated and has write access; remaining failure was the label description length.

## Authorship

Authorship: agent-codex
