### PR TITLE
ci(adr-0044): enable grid review requests

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,23 @@
+name: Grid Review Request
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  request-grid-review:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-review-request.yml@main
+    with:
+      openclaw-webhook-url: ${{ vars.OPENCLAW_GRID_REVIEW_WEBHOOK_URL || '' }}
+      review-config-path: .honeydrunk-review.yaml
+      upload-fallback-artifact: true
+      post-fallback-comment: false
+      artifact-name: grid-review-request
+    secrets:
+      openclaw-webhook-secret: ${{ secrets.OPENCLAW_GRID_REVIEW_WEBHOOK_SECRET }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  issues: write
 
 jobs:
   request-grid-review:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  issues: write
 
 jobs:
   request-grid-review:
@@ -20,3 +21,4 @@ jobs:
     secrets:
       openclaw-webhook-secret: ${{ secrets.OPENCLAW_GRID_REVIEW_WEBHOOK_SECRET }}
       github-token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.honeydrunk-review.yaml
+++ b/.honeydrunk-review.yaml
@@ -1,0 +1,8 @@
+enabled: true
+runner: openclaw-codex
+severity_floor: Suggest
+skip_paths:
+  - "**/*.Designer.cs"
+  - "**/*.g.cs"
+  - "**/generated/**"
+cost_cap_per_pr_usd: 0.00

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pr-core.yml` and `pr-sdk.yml`: wired in the CodeQL job as optional (default on) with `enable-codeql`, `codeql-queries`, and `codeql-fail-on-severity` inputs. Findings + severity breakdown appear in the PR summary comment.
 
 ### Changed
+
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for Actions PRs.
 - `pr-core.yml`: removed default-branch baseline ratcheting from PR validation orchestration so consumer PR workflows no longer require `contents: write`.
 - `docs/consumer-usage.md`: updated coverage gate examples to split read-only PR validation from write-capable default-branch ratcheting.
 - `job-static-analysis.yml`: removed the vulnerability scan step (now owned by `job-dependency-scan.yml`) and dropped its `fail-on-severity` input. `pr-core.yml` and `pr-sdk.yml` no longer pass that input.
@@ -153,6 +155,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hive project metadata cache (`.github/config/hive-project-metadata.json`) for stable project, field, and option IDs.
 
 ### Changed
+
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for Actions PRs.
 - `docs/consumer-usage.md`: documented coverage-gate inputs, `.github/coverage-baseline.json`, default-branch push wiring, and dependency issue permissions.
 - `job-coverage-analysis.yml`: marked as superseded by the PR summary coverage gate while retaining the reusable entrypoint.
 - `hive-field-mirror.yml`: accept `app-id` and `app-private-key` for GitHub App auth; PAT auth remains available as a fallback.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for Actions PRs.
 - `pr-core.yml`: removed default-branch baseline ratcheting from PR validation orchestration so consumer PR workflows no longer require `contents: write`.
 - `docs/consumer-usage.md`: updated coverage gate examples to split read-only PR validation from write-capable default-branch ratcheting.
 - `job-static-analysis.yml`: removed the vulnerability scan step (now owned by `job-dependency-scan.yml`) and dropped its `fail-on-severity` input. `pr-core.yml` and `pr-sdk.yml` no longer pass that input.
@@ -85,6 +84,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Compatible with GitHub Enterprise Server
 
 ## [Unreleased]
+
+### Internal
+
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for Actions PRs.
 
 ### Added
 - `pr-core.yml`: ADR-0044 `authorship-check`, ADR-0011/ADR-0044 `pr-metadata-check`, and warnings-only `pr-size-check` jobs. Authorship now requires a parseable `Authorship:` PR-body line; agent/mixed PRs must declare packet metadata or an explicit out-of-band reason; non-`human` PRs get visible size discipline without blocking Phase 2 merges.
@@ -156,7 +159,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for Actions PRs.
 - `docs/consumer-usage.md`: documented coverage-gate inputs, `.github/coverage-baseline.json`, default-branch push wiring, and dependency issue permissions.
 - `job-coverage-analysis.yml`: marked as superseded by the PR summary coverage gate while retaining the reusable entrypoint.
 - `hive-field-mirror.yml`: accept `app-id` and `app-private-key` for GitHub App auth; PAT auth remains available as a fallback.


### PR DESCRIPTION
## Summary
- Enable ADR-0044 OpenClaw/Codex Grid Review Runner request generation for HoneyDrunk.Actions PRs.
- Add .honeydrunk-review.yaml with advisory review enabled and standard generated-file skip paths.
- Add the pr-review.yml caller for job-review-request.yml, using the org-level OpenClaw webhook secret/variable.
- Grant issues: write to PR Core when needed for managed labels/comments.
- Note the CI tooling change in repository changelogs.

Authorship: agent-codex
Packet: HoneyDrunk.Architecture#182 / generated/issue-packets/active/adr-0044-cloud-code-review/11-cross-repo-enable-review-ten-nodes.md
Out-of-band reason: N/A

## Verification
- python C:\Users\tatte\.openclaw\workspace\validate-yaml.py .github\workflows\pr-review.yml .honeydrunk-review.yaml
- git diff --check

Size justification: N/A