### PR TITLE
fix(ci): repair weekly dependency startup failure

### DIFF
--- a/.github/workflows/nightly-deps.yml
+++ b/.github/workflows/nightly-deps.yml
@@ -264,7 +264,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.github-token || github.token }}
+          token: ${{ secrets['github-token'] || github.token }}
       
       - name: Download dependency reports
         uses: actions/download-artifact@v4
@@ -298,7 +298,7 @@ jobs:
           group-updates: ${{ inputs.group-updates }}
           labels: 'dependencies,automated'
         env:
-          GH_TOKEN: ${{ secrets.github-token || github.token }}
+          GH_TOKEN: ${{ secrets['github-token'] || github.token }}
   
   consolidate-report:
     name: Consolidate Dependency Report
@@ -335,7 +335,7 @@ jobs:
         shell: bash
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.github-token || github.token }}
+          GH_TOKEN: ${{ secrets['github-token'] || github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ISSUE_TITLE: 📦 Outdated Dependencies
         run: |


### PR DESCRIPTION
## Summary
- fix invalid GitHub Actions expressions for the reusable `github-token` secret
- replace `secrets.github-token` with bracket syntax `secrets['github-token']`

## Why
Weekly dependency workflows across consuming HoneyDrunk repos were completing immediately with `startup_failure`, no jobs, and no logs. The shared reusable workflow used dot syntax for a hyphenated secret name, which GitHub Actions cannot parse during workflow startup.

## Validation
- Confirmed 17 consumer `weekly-deps.yml` runs failed with `startup_failure` and zero jobs/logs after manual dispatch
- Verified all `secrets.github-token` references are removed
- Verified 3 bracket-syntax references remain

After merge, rerun one consumer weekly dependency workflow first, then fan out if it starts successfully.
