### PR TITLE
ci: Add HoneyDrunk.Audit mapping to repo-to-node.yml

### DIFF
--- a/.github/config/repo-to-node.yml
+++ b/.github/config/repo-to-node.yml
@@ -20,3 +20,4 @@ HoneyDrunk.Knowledge: honeydrunk-knowledge
 HoneyDrunk.Capabilities: honeydrunk-capabilities
 HoneyDrunk.Flow: honeydrunk-flow
 HoneyDrunk.Operator: honeydrunk-operator
+HoneyDrunk.Audit: honeydrunk-audit


### PR DESCRIPTION
Added mapping for HoneyDrunk.Audit to associate it with the honeydrunk-audit node in repo-to-node.yml. This enables proper routing and identification for the new audit component.

## Summary
- 

Authorship: human

Packet: N/A (required for agent/mixed PRs unless Out-of-band reason is set)
Out-of-band reason: Noticed warning in file packets, issue not warranted

## Verification
- 

Size justification: N/A
