### PR TITLE
ci(adr-0011): add job-sonarcloud.yml and wire packet-link injection in agent-run.yml

### DIFF
--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -31,6 +31,24 @@
 #       secrets:
 #         anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
 #         github-token: ${{ secrets.GITHUB_TOKEN }}
+#
+# Usage example (named agent + packet — invariant 32 enforcement):
+#   jobs:
+#     execute:
+#       uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/agent-run.yml@main
+#       with:
+#         agent: execute
+#         packet-path: generated/issue-packets/active/adr-0011-code-review-pipeline/02-actions-job-sonarcloud-workflow.md
+#         checkout-target: HoneyDrunkStudios/HoneyDrunk.Actions
+#       secrets:
+#         anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+#         github-token: ${{ secrets.AGENT_RUN_TOKEN }}
+#
+#   When `packet-path` is supplied, the workflow appends a structured "Packet:
+#   <permalink>" instruction to the agent's prompt envelope AND runs a post-hoc
+#   "Assert PR-body packet link" step that mechanically inserts the canonical
+#   `> Packet: <permalink>` line into any PR the agent opened. The workflow —
+#   not the LLM — is the mechanical guarantor of invariant 32.
 # ==============================================================================
 
 name: Agent Run
@@ -88,6 +106,19 @@ on:
         required: false
         type: string
         default: 'main'
+      packet-path:
+        description: >-
+          Optional path to the issue packet file (relative to HoneyDrunk.Architecture
+          root, e.g. generated/issue-packets/active/adr-0011-code-review-pipeline/02-actions-job-sonarcloud-workflow.md).
+          When set, the workflow (1) injects a "Packet: <permalink>" instruction
+          into the agent's prompt envelope and (2) runs a post-hoc assert step
+          that mechanically inserts the canonical "> Packet: <permalink>" line
+          into any PR the agent opened in the checkout-target repo. Together
+          these enforce invariant 32 in HoneyDrunk.Architecture regardless of
+          LLM behaviour.
+        required: false
+        type: string
+        default: ''
     secrets:
       anthropic-api-key:
         description: 'Anthropic API key. Required when provider=claude.'
@@ -146,27 +177,74 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve packet link
+        id: packet
+        env:
+          PACKET_PATH: ${{ inputs.packet-path }}
+          ARCH_REF: ${{ inputs.architecture-ref }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${PACKET_PATH}" ]]; then
+            LINK="https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/${ARCH_REF}/${PACKET_PATH}"
+            echo "link=${LINK}" >> "$GITHUB_OUTPUT"
+            echo "has-packet=true" >> "$GITHUB_OUTPUT"
+            # Verify the file exists in the checked-out Architecture tree.
+            # Warn (do not fail) on missing — hotfix and out-of-band runs may
+            # legitimately reference a packet that does not exist at this ref.
+            if [[ ! -f "${PACKET_PATH}" ]]; then
+              echo "::warning::packet-path '${PACKET_PATH}' was supplied but the file does not exist at the resolved Architecture ref (${ARCH_REF}). The PR will still be opened, but the packet link will 404 until the packet lands at that ref."
+            fi
+          else
+            echo "has-packet=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Resolve prompt
         id: resolve
         env:
           AGENT: ${{ inputs.agent }}
           PROMPT: ${{ inputs.prompt }}
+          HAS_PACKET: ${{ steps.packet.outputs.has-packet }}
+          PACKET_LINK: ${{ steps.packet.outputs.link }}
+          PACKET_PATH: ${{ inputs.packet-path }}
         run: |
           set -euo pipefail
+
+          # Build the base envelope (agent-mode vs direct-prompt-mode).
           if [[ -n "${AGENT}" ]]; then
-            {
-              echo "prompt<<EOF_PROMPT"
-              echo "You are the **${AGENT}** agent. Read your full instructions from \`.claude/agents/${AGENT}.md\` first, then execute your full workflow as described there."
-              echo "EOF_PROMPT"
-            } >> "$GITHUB_OUTPUT"
+            BASE="You are the **${AGENT}** agent. Read your full instructions from \`.claude/agents/${AGENT}.md\` first, then execute your full workflow as described there."
           else
-            {
-              echo "prompt<<EOF_PROMPT"
-              printf '%s' "${PROMPT}"
-              echo ""
-              echo "EOF_PROMPT"
-            } >> "$GITHUB_OUTPUT"
+            BASE="${PROMPT}"
           fi
+
+          # When a packet is supplied, append a structured instruction that
+          # tells the agent to include the canonical packet-link line in any
+          # PR body it opens. This is best-effort soft enforcement — the
+          # post-hoc "Assert PR-body packet link" step is the mechanical
+          # guarantor of invariant 32 if the LLM ignores this instruction.
+          if [[ "${HAS_PACKET}" == "true" ]]; then
+            PACKET_INSTRUCTION="
+
+          ---
+
+          **Issue packet for this run:** \`${PACKET_PATH}\`
+          **Packet permalink:** ${PACKET_LINK}
+
+          When you open a pull request for this work, include the following line verbatim in the PR body (this satisfies invariant 32 in HoneyDrunk.Architecture and is what the review agent uses to resolve the packet as the primary scope anchor):
+
+          > Packet: ${PACKET_LINK}
+
+          If you cannot include the link for any reason, label the PR \`out-of-band\` and explain why in the PR body."
+            FULL_PROMPT="${BASE}${PACKET_INSTRUCTION}"
+          else
+            FULL_PROMPT="${BASE}"
+          fi
+
+          {
+            echo "prompt<<EOF_PROMPT"
+            printf '%s' "${FULL_PROMPT}"
+            echo ""
+            echo "EOF_PROMPT"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Run agent — Claude
         if: ${{ inputs.provider == 'claude' || inputs.provider == '' }}
@@ -188,3 +266,57 @@ jobs:
           # TODO: wire openai/codex-action once stable
           echo "::error::Codex provider is not yet wired. Use provider: claude."
           exit 1
+
+      # Mechanical guarantor of invariant 32 (HoneyDrunk.Architecture).
+      # The prompt-side instruction in "Resolve prompt" is best-effort —
+      # this step is the workflow-side enforcement. It locates any PR the
+      # agent opened on the run's branch in the checkout-target repo and
+      # asserts the canonical "> Packet: <permalink>" line into the PR body
+      # via `gh pr edit`. Idempotent (no-op if the line is already present)
+      # and soft on edge cases (no PR, no checkout-target, detached HEAD,
+      # main-branch run → notice + exit 0).
+      - name: Assert PR-body packet link
+        if: ${{ inputs.packet-path != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.github-token }}
+          PACKET_LINK: ${{ steps.packet.outputs.link }}
+          PACKET_PATH: ${{ inputs.packet-path }}
+          CHECKOUT_TARGET: ${{ inputs.checkout-target }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${CHECKOUT_TARGET}" ]]; then
+            echo "::notice::No checkout-target — agent ran in Architecture-only mode; PR-body assert skipped (no target repo to inspect)."
+            exit 0
+          fi
+
+          # The agent runs in target-repo/ (set by the "Checkout target repo" step).
+          cd target-repo
+
+          BRANCH=$(git branch --show-current || true)
+          if [[ -z "${BRANCH}" || "${BRANCH}" == "main" ]]; then
+            echo "::notice::Agent did not open a feature branch (current=${BRANCH:-detached}); no PR to assert."
+            exit 0
+          fi
+
+          # Find the PR opened from this branch in the target repo.
+          PR_NUMBER=$(gh pr list --repo "${CHECKOUT_TARGET}" --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')
+          if [[ -z "${PR_NUMBER}" ]]; then
+            echo "::notice::Agent did not open a PR on branch '${BRANCH}' in ${CHECKOUT_TARGET}; nothing to assert."
+            exit 0
+          fi
+
+          # Read current PR body. If the exact canonical line is already present, no-op.
+          BODY=$(gh pr view "${PR_NUMBER}" --repo "${CHECKOUT_TARGET}" --json body --jq '.body // ""')
+          EXPECTED_LINE="> Packet: ${PACKET_LINK}"
+
+          if printf '%s\n' "${BODY}" | grep -Fxq "${EXPECTED_LINE}"; then
+            echo "PR #${PR_NUMBER} already contains the canonical packet link line; no edit needed."
+            exit 0
+          fi
+
+          # Otherwise, prepend the canonical packet-link block, preserving the agent's body below an `---` separator.
+          NEW_BODY=$(printf '%s\n\n---\n\n%s\n' "${EXPECTED_LINE}" "${BODY}")
+          echo "Asserting canonical packet link on PR #${PR_NUMBER} in ${CHECKOUT_TARGET}."
+          gh pr edit "${PR_NUMBER}" --repo "${CHECKOUT_TARGET}" --body "${NEW_BODY}"

--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -185,14 +185,19 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -n "${PACKET_PATH}" ]]; then
-            LINK="https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/${ARCH_REF}/${PACKET_PATH}"
+            # Resolve the Architecture checkout's actual commit SHA so the
+            # produced URL is a true permalink — won't move if the ref
+            # (e.g. 'main') advances after this run. Falls back to the
+            # input ref if SHA resolution fails for any reason.
+            ARCH_SHA=$(git rev-parse HEAD 2>/dev/null || echo "${ARCH_REF}")
+            LINK="https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/${ARCH_SHA}/${PACKET_PATH}"
             echo "link=${LINK}" >> "$GITHUB_OUTPUT"
             echo "has-packet=true" >> "$GITHUB_OUTPUT"
             # Verify the file exists in the checked-out Architecture tree.
             # Warn (do not fail) on missing — hotfix and out-of-band runs may
             # legitimately reference a packet that does not exist at this ref.
             if [[ ! -f "${PACKET_PATH}" ]]; then
-              echo "::warning::packet-path '${PACKET_PATH}' was supplied but the file does not exist at the resolved Architecture ref (${ARCH_REF}). The PR will still be opened, but the packet link will 404 until the packet lands at that ref."
+              echo "::warning::packet-path '${PACKET_PATH}' was supplied but the file does not exist at the resolved Architecture ref (ref=${ARCH_REF}, sha=${ARCH_SHA}). The PR will still be opened, but the packet link will 404 until the packet lands at that ref."
             fi
           else
             echo "has-packet=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/job-sonarcloud.yml
+++ b/.github/workflows/job-sonarcloud.yml
@@ -1,0 +1,207 @@
+# ==============================================================================
+# SonarQube Cloud Static Analysis Job (Tier 2)
+# ==============================================================================
+# Purpose:
+#   Run SonarQube Cloud (formerly SonarCloud — rebrand 2026) static analysis
+#   on a .NET repo using `dotnet-sonarscanner`. Reuses the coverage artifact
+#   from `job-build-and-test.yml`, publishes coverage to SonarQube Cloud,
+#   and reports the SonarQube Cloud quality gate as a PR check.
+#
+# Tier:
+#   Tier 2 of the ADR-0011 PR review pipeline. Required check on public repos
+#   per ADR-0011 D11.
+#
+# CALLER TRIGGER CONTRACT (load-bearing — read this if you are wiring a new caller):
+#   This workflow is `workflow_call`-only. It MUST only be invoked from a
+#   caller workflow whose `on:` block fires on `pull_request` events or `push`
+#   events to `main` — not on every feature-branch push, not on tags, not on
+#   schedule, not on workflow_dispatch from arbitrary refs.
+#
+#   The job below carries an `if:` guard that refuses to run when this
+#   constraint is violated, so a misconfigured caller will produce a no-op
+#   skipped job rather than burning a SonarQube Cloud run on every
+#   feature-branch push. Per ADR-0011 D11 cost discipline.
+#
+# Cost discipline:
+#   - pull_request and push:main only — enforced by both the caller's `on:`
+#     block AND the job-level `if:` guard below
+#   - Median PR run target: under 60 seconds
+#   - Coverage report reused from `job-build-and-test.yml` artifact (no second
+#     `dotnet test` run)
+#   - SonarQube Cloud OSS plan: free for unlimited public LOC; private LOC is
+#     paid per LOC and is intentionally out of scope (ADR-0011 D11 Gap 5)
+#
+# Secret:
+#   SONAR_TOKEN — provisioned as a GitHub org secret with `Selected repositories`
+#   scope. Provisioning lives in `infrastructure/walkthroughs/sonarcloud-organization-setup.md`
+#   in HoneyDrunk.Architecture. Free/OSS plan caps Personal Access Token
+#   expiration at 60 days — rotation discipline is tracked on the operator's
+#   calendar; the broader external-SaaS credential rotation policy is being
+#   formalized in a separate ADR (see `generated/adr-drafts/`).
+#
+# Single Responsibility:
+#   SonarQube Cloud analysis only. Does not run tests (reuses
+#   `job-build-and-test.yml`'s coverage artifact). Does not gate on Sonar Way
+#   quality-gate failure — failure surfaces via the PR check that SonarQube
+#   Cloud itself publishes; branch protection enforces it as a required check
+#   on a per-repo basis.
+#
+# Non-goals:
+#   Vulnerability scanning (see `job-dependency-scan.yml`), CodeQL SAST (see
+#   `job-codeql.yml`), secret scanning (see `job-secret-scan.yml`), analyzers
+#   and formatting (see `job-static-analysis.yml`).
+# ==============================================================================
+
+name: SonarQube Cloud (Job)
+
+on:
+  workflow_call:
+    inputs:
+      dotnet-version:
+        description: 'The .NET SDK version to use'
+        required: false
+        type: string
+        default: '10.0.x'
+
+      runs-on:
+        description: 'GitHub runner to use'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+
+      working-directory:
+        description: 'Working directory for build (inner project subdir, NOT git root)'
+        required: false
+        type: string
+        default: '.'
+
+      project-path:
+        description: 'Path to solution or project file (auto-detected if not specified)'
+        required: false
+        type: string
+        default: ''
+
+      sonar-organization:
+        description: 'SonarQube Cloud organization key (e.g. honeydrunkstudios)'
+        required: true
+        type: string
+
+      sonar-project-key:
+        description: 'SonarQube Cloud project key (e.g. honeydrunkstudios_HoneyDrunk.Kernel)'
+        required: true
+        type: string
+
+      sonar-host-url:
+        description: 'SonarQube Cloud host URL'
+        required: false
+        type: string
+        default: 'https://sonarcloud.io'
+
+      coverage-artifact-name:
+        description: 'Name of the coverage artifact uploaded by job-build-and-test.yml'
+        required: false
+        type: string
+        default: 'coverage-reports-ubuntu-latest'
+
+    secrets:
+      sonar-token:
+        description: 'SONAR_TOKEN — GitHub org secret scoped to HoneyDrunkStudios. Provisioning lives in HoneyDrunk.Architecture/infrastructure/walkthroughs/sonarcloud-organization-setup.md.'
+        required: true
+      github-token:
+        description: 'GitHub token for PR decoration (falls back to github.token if not supplied)'
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  sonarcloud:
+    name: SonarQube Cloud
+    runs-on: ${{ inputs.runs-on }}
+    # Trigger guard — defence in depth for ADR-0011 D11 cost discipline.
+    # Refuses to run when invoked from a misconfigured caller. The expected
+    # caller `on:` block is `pull_request` and `push: branches: [main]`.
+    # If a caller wires this workflow into a feature-branch push or a tag,
+    # this guard reports a skipped job rather than spending a SonarQube Cloud run.
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # SonarQube Cloud requires full git history for blame attribution
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+
+      - name: Set up Java (required by Sonar Scanner)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Cache SonarQube Cloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Cache SonarQube Cloud scanner
+        id: cache-sonar-scanner
+        uses: actions/cache@v4
+        with:
+          path: ./.sonar/scanner
+          key: ${{ runner.os }}-sonar-scanner
+          restore-keys: ${{ runner.os }}-sonar-scanner
+
+      - name: Install SonarQube Cloud scanner
+        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir -p ./.sonar/scanner
+          dotnet tool update dotnet-sonarscanner --tool-path ./.sonar/scanner
+
+      - name: Download coverage artifact (if exists)
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.coverage-artifact-name }}
+          path: TestResults
+        continue-on-error: true
+
+      - name: Begin SonarQube Cloud analysis
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          SONAR_TOKEN: ${{ secrets.sonar-token }}
+          GITHUB_TOKEN: ${{ secrets.github-token || github.token }}
+        shell: bash
+        run: |
+          ./.sonar/scanner/dotnet-sonarscanner begin \
+            /k:"${{ inputs.sonar-project-key }}" \
+            /o:"${{ inputs.sonar-organization }}" \
+            /d:sonar.host.url="${{ inputs.sonar-host-url }}" \
+            /d:sonar.token="${SONAR_TOKEN}" \
+            /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
+
+      - name: Build
+        working-directory: ${{ inputs.working-directory }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.project-path }}" ]; then
+            dotnet build "${{ inputs.project-path }}" --configuration Release
+          else
+            dotnet build --configuration Release
+          fi
+
+      - name: End SonarQube Cloud analysis
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          SONAR_TOKEN: ${{ secrets.sonar-token }}
+        shell: bash
+        run: |
+          ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${SONAR_TOKEN}"

--- a/.github/workflows/job-sonarcloud.yml
+++ b/.github/workflows/job-sonarcloud.yml
@@ -155,7 +155,11 @@ jobs:
         id: cache-sonar-scanner
         uses: actions/cache@v4
         with:
-          path: ./.sonar/scanner
+          # Scanner cached at workspace root so the absolute
+          # $GITHUB_WORKSPACE/.sonar/scanner path resolves regardless of the
+          # caller's working-directory (which may be an inner subdir like
+          # 'HoneyDrunk.Kernel/' for Pattern A consumer repos).
+          path: ${{ github.workspace }}/.sonar/scanner
           key: ${{ runner.os }}-sonar-scanner
           restore-keys: ${{ runner.os }}-sonar-scanner
 
@@ -163,15 +167,54 @@ jobs:
         if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          mkdir -p ./.sonar/scanner
-          dotnet tool update dotnet-sonarscanner --tool-path ./.sonar/scanner
+          mkdir -p "${GITHUB_WORKSPACE}/.sonar/scanner"
+          dotnet tool update dotnet-sonarscanner --tool-path "${GITHUB_WORKSPACE}/.sonar/scanner"
+
+      - name: Install ReportGenerator (Cobertura → OpenCover conversion)
+        shell: bash
+        run: |
+          # job-build-and-test.yml emits Cobertura via `dotnet test --collect "XPlat Code Coverage"`.
+          # SonarQube Cloud for C# natively supports OpenCover (per the official .NET
+          # test coverage docs), not Cobertura. Convert before the scanner reads coverage.
+          mkdir -p "${GITHUB_WORKSPACE}/.sonar/reportgenerator"
+          dotnet tool update dotnet-reportgenerator-globaltool --tool-path "${GITHUB_WORKSPACE}/.sonar/reportgenerator"
 
       - name: Download coverage artifact (if exists)
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.coverage-artifact-name }}
-          path: TestResults
+          # Download into the caller's working-directory so the relative
+          # `**/coverage.*.xml` globs in sonar-project.properties resolve
+          # against the same root the scanner runs from.
+          path: ${{ inputs.working-directory }}/TestResults
         continue-on-error: true
+
+      - name: Convert Cobertura coverage to OpenCover
+        working-directory: ${{ inputs.working-directory }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Find any Cobertura xml files dropped by the download step. Skip
+          # silently if none exist — first-onboarding runs and no-coverage-collected
+          # runs should still produce a quality-gate verdict (coverage just won't
+          # be imported on that run).
+          mapfile -t COBERTURA_FILES < <(find ./TestResults -name "coverage.cobertura.xml" 2>/dev/null || true)
+          if [ "${#COBERTURA_FILES[@]}" -eq 0 ]; then
+            echo "::notice::No coverage.cobertura.xml found in TestResults/ — SonarQube Cloud will run without coverage data."
+            exit 0
+          fi
+          echo "Converting ${#COBERTURA_FILES[@]} Cobertura report(s) to OpenCover format..."
+          REPORTS=$(IFS=';'; echo "${COBERTURA_FILES[*]}")
+          "${GITHUB_WORKSPACE}/.sonar/reportgenerator/reportgenerator" \
+            -reports:"${REPORTS}" \
+            -targetdir:./TestResults/opencover \
+            -reporttypes:OpenCover
+          # Place the converted report at a stable path discoverable by the
+          # `**/coverage.opencover.xml` glob in per-repo sonar-project.properties.
+          if [ -f ./TestResults/opencover/OpenCover.xml ]; then
+            mv ./TestResults/opencover/OpenCover.xml ./TestResults/coverage.opencover.xml
+            echo "OpenCover report written to TestResults/coverage.opencover.xml"
+          fi
 
       - name: Begin SonarQube Cloud analysis
         working-directory: ${{ inputs.working-directory }}
@@ -180,12 +223,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.github-token || github.token }}
         shell: bash
         run: |
-          ./.sonar/scanner/dotnet-sonarscanner begin \
+          # Coverage report paths come from per-repo sonar-project.properties
+          # (sonar.cs.opencover.reportsPaths = **/coverage.opencover.xml) — not
+          # hard-coded here, so per-repo config can diverge cleanly if needed.
+          "${GITHUB_WORKSPACE}/.sonar/scanner/dotnet-sonarscanner" begin \
             /k:"${{ inputs.sonar-project-key }}" \
             /o:"${{ inputs.sonar-organization }}" \
             /d:sonar.host.url="${{ inputs.sonar-host-url }}" \
-            /d:sonar.token="${SONAR_TOKEN}" \
-            /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
+            /d:sonar.token="${SONAR_TOKEN}"
 
       - name: Build
         working-directory: ${{ inputs.working-directory }}
@@ -204,4 +249,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.sonar-token }}
         shell: bash
         run: |
-          ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${SONAR_TOKEN}"
+          "${GITHUB_WORKSPACE}/.sonar/scanner/dotnet-sonarscanner" end /d:sonar.token="${SONAR_TOKEN}"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the GitHub Actions template library will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `job-sonarcloud.yml`: new tier-2 reusable workflow that runs SonarQube Cloud (formerly SonarCloud) static analysis on a .NET repo via `dotnet-sonarscanner`. Reuses the coverage artifact from `job-build-and-test.yml` (no double `dotnet test`), converts Cobertura → OpenCover via ReportGenerator before the scanner reads coverage (Sonar's native C# format), and reports the SonarQube Cloud quality gate as a PR check. Job-level `if:` guard enforces `pull_request` + `push:main` only as defence in depth for ADR-0011 D11 cost discipline. Inputs include `working-directory` (supports inner-subdir Pattern A layouts), `sonar-organization`, `sonar-project-key`, and `coverage-artifact-name`. Per ADR-0011 packet 02.
+
+### Changed
+
+- `agent-run.yml`: added optional `packet-path` input. When supplied, the workflow (1) injects a structured `> Packet: <permalink>` instruction into the agent's prompt envelope and (2) runs a post-hoc "Assert PR-body packet link" step that mechanically inserts the canonical line into any PR the agent opened in the `checkout-target` repo. The workflow — not the LLM — is the mechanical guarantor of invariant 32 in HoneyDrunk.Architecture. The permalink resolves to the Architecture checkout's actual commit SHA (via `git rev-parse HEAD`) so the link is immutable, not a moving branch ref. Idempotent (no edit if the canonical line is already present) and soft on edge cases (no PR / no checkout-target / detached HEAD / main-branch run → notice + exit 0). Existing callers unaffected — `packet-path` defaults to empty. Per ADR-0011 packet 03.
+
 ## [1.0.1] - 2026-04-18
 
 ### Added


### PR DESCRIPTION
## Summary

Wave 1 of the ADR-0011 SonarQube Cloud rollout — Actions-side plumbing. Two packets bundled in one Actions PR per the one-commit-per-repo-per-initiative discipline.

**Packet 02 — `job-sonarcloud.yml` (new reusable workflow):**
- Runs `dotnet-sonarscanner` against the consumer's .NET tree
- Reuses the coverage artifact from `job-build-and-test.yml` — no double `dotnet test`, per ADR-0011 D11 cost discipline (median PR run target < 60s)
- `if:` guard at job level enforces `pull_request` + `push:main` only — defence in depth against misconfigured callers that would otherwise burn SonarQube Cloud runs on feature-branch pushes
- Permissions minimal: `contents: read`, `pull-requests: write`, `checks: write`
- Inputs: `dotnet-version`, `working-directory`, `project-path`, `sonar-organization`, `sonar-project-key`, `sonar-host-url`, `coverage-artifact-name`
- Secrets: `SONAR_TOKEN` (required), `github-token` (optional fallback to `github.token`)
- `fetch-depth: 0` mandatory for SonarQube Cloud's blame attribution
- Java 17 Temurin installed (Sonar Scanner is JVM-based)
- Two-layer caching: `~/.sonar/cache` + `./.sonar/scanner`

**Packet 03 — `agent-run.yml` packet-link injection:**
- New optional `packet-path` input (default empty — existing callers unaffected)
- New "Resolve packet link" step computes the Architecture permalink via `inputs.architecture-ref`
- "Resolve prompt" amended to append a structured `> Packet: <permalink>` instruction to the agent's envelope when `packet-path` is supplied (soft enforcement of invariant 32)
- **New "Assert PR-body packet link" step** — the **mechanical guarantor** of invariant 32. After the agent run, locates any PR opened on the run's branch in `checkout-target` and uses `gh pr edit` to insert the canonical `> Packet: <permalink>` line into the PR body. Idempotent, soft on edge cases (no PR / no checkout-target / detached HEAD / main-branch run → notice + exit 0)

Both changes are additive — `job-sonarcloud.yml` is new, `agent-run.yml`'s `packet-path` is optional with empty default. No existing caller breaks.

## Test plan

- [ ] `actionlint` (via `actions-ci.yml`) passes
- [ ] No existing `agent-run.yml` caller breaks (no caller passes `packet-path` yet)
- [ ] `job-sonarcloud.yml` first consumer (Kernel PR — see HoneyDrunk.Kernel#PENDING) successfully runs after this PR merges
- [ ] First Kernel SonarQube Cloud run auto-creates the `honeydrunkstudios_HoneyDrunk.Kernel` project at https://sonarcloud.io/organizations/honeydrunkstudios
- [ ] `agent-run.yml` post-hoc assert step is exercised by any future `packet-path`-supplying caller (none in flight yet — input is reserved for future packet-execution drivers)

## Sequence

This PR must merge **before** the Kernel and Audit onboarding PRs (HoneyDrunk.Kernel and HoneyDrunk.Audit, both branch `adr-0011-sonarcloud-onboarding`) can run successfully — their `sonarcloud` jobs reference `job-sonarcloud.yml@main`. Those PRs are pushed as drafts pending this merge.

Refs: ADR-0011 D2/D6/D11, invariant 32, packets 02 and 03 in HoneyDrunk.Architecture/generated/issue-packets/active/adr-0011-code-review-pipeline/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Authorship: agent-claude-code