### PR TITLE
ci(adr-0012): add Grid Health and D4 rollout

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -26,7 +26,10 @@ jobs:
           set -euo pipefail
           INSTALL_DIR="$RUNNER_TEMP/actionlint"
           mkdir -p "$INSTALL_DIR"
-          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) "$ACTIONLINT_VERSION" "$INSTALL_DIR"
+          curl -sSfL \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            -o "$RUNNER_TEMP/actionlint.tar.gz"
+          tar -xzf "$RUNNER_TEMP/actionlint.tar.gz" -C "$INSTALL_DIR" actionlint
           echo "$INSTALL_DIR" >> "$GITHUB_PATH"
 
       - name: Run actionlint

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -18,10 +18,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install actionlint
+        shell: bash
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+        run: |
+          set -euo pipefail
+          INSTALL_DIR="$RUNNER_TEMP/actionlint"
+          mkdir -p "$INSTALL_DIR"
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) "$ACTIONLINT_VERSION" "$INSTALL_DIR"
+          echo "$INSTALL_DIR" >> "$GITHUB_PATH"
+
       - name: Run actionlint
-        uses: docker://rhysd/actionlint:1.7.12
-        with:
-          args: -color -shellcheck=
+        shell: bash
+        run: |
+          set -euo pipefail
+          actionlint -color -shellcheck=
 
       - name: Check banned CI secret patterns
         shell: bash

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -26,7 +26,12 @@ jobs:
           set -euo pipefail
           INSTALL_DIR="$RUNNER_TEMP/actionlint"
           mkdir -p "$INSTALL_DIR"
-          ACTIONLINT_ARCHIVE="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          case "$(uname -m)" in
+            x86_64|amd64) ACTIONLINT_ARCH=amd64 ;;
+            aarch64|arm64) ACTIONLINT_ARCH=arm64 ;;
+            *) echo "::error::Unsupported runner architecture for actionlint: $(uname -m)"; exit 1 ;;
+          esac
+          ACTIONLINT_ARCHIVE="actionlint_${ACTIONLINT_VERSION}_linux_${ACTIONLINT_ARCH}.tar.gz"
           curl -sSfL \
             "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${ACTIONLINT_ARCHIVE}" \
             -o "$RUNNER_TEMP/$ACTIONLINT_ARCHIVE"
@@ -71,3 +76,9 @@ jobs:
           fi
 
           echo "No banned direct-secret patterns found."
+
+      - name: Smoke test Grid Health aggregator
+        shell: bash
+        run: |
+          set -euo pipefail
+          tests/grid-health-aggregator-smoke.sh

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -26,10 +26,15 @@ jobs:
           set -euo pipefail
           INSTALL_DIR="$RUNNER_TEMP/actionlint"
           mkdir -p "$INSTALL_DIR"
+          ACTIONLINT_ARCHIVE="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           curl -sSfL \
-            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
-            -o "$RUNNER_TEMP/actionlint.tar.gz"
-          tar -xzf "$RUNNER_TEMP/actionlint.tar.gz" -C "$INSTALL_DIR" actionlint
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${ACTIONLINT_ARCHIVE}" \
+            -o "$RUNNER_TEMP/$ACTIONLINT_ARCHIVE"
+          curl -sSfL \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_checksums.txt" \
+            -o "$RUNNER_TEMP/actionlint_checksums.txt"
+          (cd "$RUNNER_TEMP" && grep "  ${ACTIONLINT_ARCHIVE}$" actionlint_checksums.txt | sha256sum -c -)
+          tar -xzf "$RUNNER_TEMP/$ACTIONLINT_ARCHIVE" -C "$INSTALL_DIR" actionlint
           echo "$INSTALL_DIR" >> "$GITHUB_PATH"
 
       - name: Run actionlint

--- a/.github/workflows/grid-health-report.yml
+++ b/.github/workflows/grid-health-report.yml
@@ -20,7 +20,6 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GRID_HEALTH_PAT }}
       GRID_HEALTH_TITLE: "Grid Health"
-      ARCHITECTURE_REPO: HoneyDrunkStudios/HoneyDrunk.Architecture
       ACTIONS_REPO: HoneyDrunkStudios/HoneyDrunk.Actions
     steps:
       - name: Checkout Actions

--- a/.github/workflows/grid-health-report.yml
+++ b/.github/workflows/grid-health-report.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GRID_HEALTH_PAT }}
-      GRID_HEALTH_TITLE: "🕸️ Grid Health"
+      GRID_HEALTH_TITLE: "Grid Health"
       ARCHITECTURE_REPO: HoneyDrunkStudios/HoneyDrunk.Architecture
       ACTIONS_REPO: HoneyDrunkStudios/HoneyDrunk.Actions
     steps:
@@ -31,6 +31,7 @@ jobs:
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Architecture
           path: architecture
+          token: ${{ secrets.GRID_HEALTH_PAT }}
           sparse-checkout: catalogs/grid-health.json
           sparse-checkout-cone-mode: false
 
@@ -39,7 +40,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "ERROR: GRID_HEALTH_PAT secret is required. Scope it to Issues: Write on every repo with tracked_workflows plus HoneyDrunk.Actions." >&2
+            echo "ERROR: GRID_HEALTH_PAT secret is required. It must read HoneyDrunk.Architecture, read Actions workflow runs and org repo metadata, and write Issues on HoneyDrunk.Actions plus every repo with tracked_workflows." >&2
             exit 1
           fi
           gh auth status >/dev/null

--- a/.github/workflows/grid-health-report.yml
+++ b/.github/workflows/grid-health-report.yml
@@ -1,0 +1,49 @@
+name: Grid Health Report
+
+on:
+  schedule:
+    - cron: "30 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: grid-health-report
+  cancel-in-progress: false
+
+jobs:
+  grid-health:
+    name: Render Grid Health
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GRID_HEALTH_PAT }}
+      GRID_HEALTH_TITLE: "🕸️ Grid Health"
+      ARCHITECTURE_REPO: HoneyDrunkStudios/HoneyDrunk.Architecture
+      ACTIONS_REPO: HoneyDrunkStudios/HoneyDrunk.Actions
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v4
+
+      - name: Checkout Architecture catalog
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Architecture
+          path: architecture
+          sparse-checkout: catalogs/grid-health.json
+          sparse-checkout-cone-mode: false
+
+      - name: Validate GRID_HEALTH_PAT
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "ERROR: GRID_HEALTH_PAT secret is required. Scope it to Issues: Write on every repo with tracked_workflows plus HoneyDrunk.Actions." >&2
+            exit 1
+          fi
+          gh auth status >/dev/null
+
+      - name: Generate report and maintain issues
+        shell: bash
+        run: scripts/grid-health-aggregator.sh architecture/catalogs/grid-health.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,8 +319,16 @@ jobs:
           SYFT_VERSION: v1.44.0
         run: |
           set -euo pipefail
-          curl -sSfL "https://raw.githubusercontent.com/anchore/syft/main/install.sh" | sh -s -- -b "$RUNNER_TEMP/syft" "$SYFT_VERSION"
-          "$RUNNER_TEMP/syft/syft" "dir:${{ inputs.working-directory }}"             --output "spdx-json=${{ inputs.working-directory }}/artifacts/sbom.spdx.json"
+          INSTALL_DIR="$RUNNER_TEMP/syft"
+          mkdir -p "$INSTALL_DIR"
+          SYFT_ARCHIVE="syft_${SYFT_VERSION#v}_linux_amd64.tar.gz"
+          curl -sSfL \
+            "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/${SYFT_ARCHIVE}" \
+            -o "$RUNNER_TEMP/$SYFT_ARCHIVE"
+          tar -xzf "$RUNNER_TEMP/$SYFT_ARCHIVE" -C "$INSTALL_DIR" syft
+          "$INSTALL_DIR/syft" \
+            "dir:${{ inputs.working-directory }}" \
+            --output "spdx-json=${{ inputs.working-directory }}/artifacts/sbom.spdx.json"
 
       - name: Run license compliance check
         shell: bash
@@ -609,7 +617,17 @@ jobs:
           TRIVY_IMAGE: aquasec/trivy:0.69.3
         run: |
           set -euo pipefail
-          docker run --rm             -v "$PWD:/workspace"             -v /var/run/docker.sock:/var/run/docker.sock             -w /workspace             "$TRIVY_IMAGE"             image             --format sarif             --output container-scan.sarif             --severity HIGH,CRITICAL             --exit-code 1             "${{ steps.container_tags.outputs.image_tag }}"
+          docker run --rm \
+            -v "$PWD:/workspace" \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -w /workspace \
+            "$TRIVY_IMAGE" \
+            image \
+            --format sarif \
+            --output container-scan.sarif \
+            --severity HIGH,CRITICAL \
+            --exit-code 1 \
+            "${{ steps.container_tags.outputs.image_tag }}"
 
       - name: Upload container scan to GitHub Security
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,10 +321,19 @@ jobs:
           set -euo pipefail
           INSTALL_DIR="$RUNNER_TEMP/syft"
           mkdir -p "$INSTALL_DIR"
-          SYFT_ARCHIVE="syft_${SYFT_VERSION#v}_linux_amd64.tar.gz"
+          case "$(uname -m)" in
+            x86_64|amd64) SYFT_ARCH=amd64 ;;
+            aarch64|arm64) SYFT_ARCH=arm64 ;;
+            *) echo "::error::Unsupported runner architecture for Syft: $(uname -m)"; exit 1 ;;
+          esac
+          SYFT_ARCHIVE="syft_${SYFT_VERSION#v}_linux_${SYFT_ARCH}.tar.gz"
           curl -sSfL \
             "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/${SYFT_ARCHIVE}" \
             -o "$RUNNER_TEMP/$SYFT_ARCHIVE"
+          curl -sSfL \
+            "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/syft_${SYFT_VERSION#v}_checksums.txt" \
+            -o "$RUNNER_TEMP/syft_checksums.txt"
+          (cd "$RUNNER_TEMP" && grep "  ${SYFT_ARCHIVE}$" syft_checksums.txt | sha256sum -c -)
           tar -xzf "$RUNNER_TEMP/$SYFT_ARCHIVE" -C "$INSTALL_DIR" syft
           "$INSTALL_DIR/syft" \
             "dir:${{ inputs.working-directory }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,12 +314,13 @@ jobs:
         run: mkdir -p "${{ inputs.working-directory }}/artifacts"
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
-        with:
-          path: ${{ inputs.working-directory }}
-          format: spdx-json
-          output-file: ${{ inputs.working-directory }}/artifacts/sbom.spdx.json
-          upload-artifact: false
+        shell: bash
+        env:
+          SYFT_VERSION: v1.44.0
+        run: |
+          set -euo pipefail
+          curl -sSfL "https://raw.githubusercontent.com/anchore/syft/main/install.sh" | sh -s -- -b "$RUNNER_TEMP/syft" "$SYFT_VERSION"
+          "$RUNNER_TEMP/syft/syft" "dir:${{ inputs.working-directory }}"             --output "spdx-json=${{ inputs.working-directory }}/artifacts/sbom.spdx.json"
 
       - name: Run license compliance check
         shell: bash
@@ -603,13 +604,12 @@ jobs:
           echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
       
       - name: Scan container image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.35.0
-        with:
-          image-ref: ${{ steps.container_tags.outputs.image_tag }}
-          format: 'sarif'
-          output: 'container-scan.sarif'
-          severity: 'HIGH,CRITICAL'
-          exit-code: '1'
+        shell: bash
+        env:
+          TRIVY_IMAGE: aquasec/trivy:0.69.3
+        run: |
+          set -euo pipefail
+          docker run --rm             -v "$PWD:/workspace"             -v /var/run/docker.sock:/var/run/docker.sock             -w /workspace             "$TRIVY_IMAGE"             image             --format sarif             --output container-scan.sarif             --severity HIGH,CRITICAL             --exit-code 1             "${{ steps.container_tags.outputs.image_tag }}"
 
       - name: Upload container scan to GitHub Security
         if: always()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pr-core.yml` and `pr-sdk.yml`: wired in the CodeQL job as optional (default on) with `enable-codeql`, `codeql-queries`, and `codeql-fail-on-severity` inputs. Findings + severity breakdown appear in the PR summary comment.
 
 ### Changed
+- `grid-health-report.yml`: added the ADR-0012 D6 Grid Health aggregator workflow, shell implementation, and operator guide.
+- `docs/action-pins.md`: added the ADR-0012 D10 third-party action pin inventory.
+- `release.yml`: migrated Trivy and SBOM generation from marketplace wrappers to direct Trivy/Syft CLI invocation per ADR-0012 D4.
+- `actions-ci.yml`: chose D4 Outcome B for `docker://` refs and migrated actionlint to direct install-and-invoke.
+- `docs/d4-retrofit-audit.md`: recorded the D4 retrofit audit and `docker://` policy clarification.
 
 - `pr-core.yml`: removed default-branch baseline ratcheting from PR validation orchestration so consumer PR workflows no longer require `contents: write`.
 - `docs/consumer-usage.md`: updated coverage gate examples to split read-only PR validation from write-capable default-branch ratcheting.
@@ -84,6 +89,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Compatible with GitHub Enterprise Server
 
 ## [Unreleased]
+
+### Changed
+- `docs/consumer-usage.md`: documented ADR-0012 D5/D9 caller-permissions baselines and refreshed reusable-workflow examples so callers declare the load-bearing `permissions:` blocks required by invariant 39.
 
 ### Internal
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the GitHub Actions template library will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- `actions-ci.yml`: chose D4 Outcome B for `docker://` refs and migrated actionlint to direct install-and-invoke.
+- `docs/action-pins.md`: added the ADR-0012 D10 third-party action pin inventory.
+- `docs/d4-retrofit-audit.md`: recorded the D4 retrofit audit and `docker://` policy clarification.
+- `grid-health-report.yml`: added the ADR-0012 D6 Grid Health aggregator workflow, shell implementation, and operator guide.
+- `release.yml`: migrated Trivy and SBOM generation from marketplace wrappers to direct Trivy/Syft CLI invocation per ADR-0012 D4.
+
 ## [1.0.1] - 2026-04-18
 
 ### Added
@@ -16,12 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pr-core.yml` and `pr-sdk.yml`: wired in the CodeQL job as optional (default on) with `enable-codeql`, `codeql-queries`, and `codeql-fail-on-severity` inputs. Findings + severity breakdown appear in the PR summary comment.
 
 ### Changed
-- `grid-health-report.yml`: added the ADR-0012 D6 Grid Health aggregator workflow, shell implementation, and operator guide.
-- `docs/action-pins.md`: added the ADR-0012 D10 third-party action pin inventory.
-- `release.yml`: migrated Trivy and SBOM generation from marketplace wrappers to direct Trivy/Syft CLI invocation per ADR-0012 D4.
-- `actions-ci.yml`: chose D4 Outcome B for `docker://` refs and migrated actionlint to direct install-and-invoke.
-- `docs/d4-retrofit-audit.md`: recorded the D4 retrofit audit and `docker://` policy clarification.
-
 - `pr-core.yml`: removed default-branch baseline ratcheting from PR validation orchestration so consumer PR workflows no longer require `contents: write`.
 - `docs/consumer-usage.md`: updated coverage gate examples to split read-only PR validation from write-capable default-branch ratcheting.
 - `job-static-analysis.yml`: removed the vulnerability scan step (now owned by `job-dependency-scan.yml`) and dropped its `fail-on-severity` input. `pr-core.yml` and `pr-sdk.yml` no longer pass that input.

--- a/docs/action-pins.md
+++ b/docs/action-pins.md
@@ -1,0 +1,44 @@
+# Action Pin Inventory
+
+This inventory tracks third-party GitHub Action pins used by `HoneyDrunk.Actions` workflows and composite actions. It implements ADR-0012 D10: action runtime/deprecation state lives in one reviewable document instead of being rediscovered from workflow logs.
+
+Any PR that adds, removes, or changes a `uses:` pin updates this file in the same PR. Stale entries are a review observation because they hide deprecation work until CI starts warning or failing.
+
+## Inventory
+
+| Action | Current pin | Deprecation deadline | Status | Successor | Notes |
+|---|---|---|---|---|---|
+| actions/cache | v4 | 2026-09-16 | Deprecated-with-deadline | actions/cache@v5 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
+| actions/checkout | v4 | 2026-09-16 | Deprecated-with-deadline | actions/checkout@v5 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
+| actions/create-github-app-token | v1 | unknown | Current | none | none |
+| actions/download-artifact | v4 | 2026-09-16 | Deprecated-with-deadline | actions/download-artifact@v5 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
+| actions/setup-dotnet | v4 | 2026-09-16 | Deprecated-with-deadline | actions/setup-dotnet@v5 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
+| actions/setup-node | v4 | 2026-09-16 | Deprecated-with-deadline | actions/setup-node@v5 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
+| actions/upload-artifact | v4 | 2026-09-16 | Deprecated-with-deadline | actions/upload-artifact@v5 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
+| anthropics/claude-code-action | v1 | unknown | Current | none | none |
+| azure/functions-action | v1 | unknown | Current | none | none |
+| azure/functions-action | v2 | unknown | Current | none | none |
+| azure/login | v2 | unknown | Current | none | none |
+| azure/webapps-deploy | v3 | unknown | Current | none | none |
+| docker/login-action | v3 | unknown | Current | none | none |
+| docker/setup-buildx-action | v3 | unknown | Current | none | none |
+| EnricoMi/publish-unit-test-result-action | v2 | unknown | Current | none | none |
+| github/codeql-action/analyze | v3 | 2026-09-16 | Deprecated-with-deadline | github/codeql-action/analyze@v4 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
+| github/codeql-action/init | v3 | 2026-09-16 | Deprecated-with-deadline | github/codeql-action/init@v4 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
+| github/codeql-action/upload-sarif | v3 | 2026-09-16 | Deprecated-with-deadline | github/codeql-action/upload-sarif@v4 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
+| peter-evans/create-or-update-comment | v4 | unknown | Current | none | none |
+| peter-evans/create-pull-request | v6 | unknown | Current | none | none |
+| peter-evans/find-comment | v3 | unknown | Current | none | none |
+
+## Update protocol
+
+- Any PR that adds, removes, or changes an action pin updates this file in the same PR.
+- Bumping a `Deprecated-with-deadline` entry to its successor flips `Status` to `Current` and sets the deadline to `none` until a new deprecation is announced.
+- Removing an action entirely, such as replacing a marketplace wrapper with direct CLI invocation per invariant 38, deletes the row or records the direct-CLI successor when useful for audit continuity.
+- A PR that changes a `uses:` line without updating this inventory is Request Changes unless the changed reference is local (`./...`) or another `HoneyDrunk.Actions` reusable workflow reference.
+
+## Cross-references
+
+- HoneyDrunk.Architecture invariant 38 — reusable workflows invoke tool CLIs directly; this inventory covers the permitted third-party/first-party action surface that remains.
+- ADR-0012 D10 — action-pin inventory and update cadence.
+- ADR-0012 Gap 5 — future optional workflow can parse `uses:` pins and diff them against this inventory.

--- a/docs/consumer-usage.md
+++ b/docs/consumer-usage.md
@@ -233,7 +233,7 @@ jobs:
 
 ### Permissions
 
-`pr-core.yml` callers need an explicit top-level or job-level permissions block that grants `contents: read`, `checks: write`, `pull-requests: write`, and `security-events: write`; examples that enable metadata/size label management also grant `issues: write`. Under `workflow_call`, the callee declaration is documentary, so missing or under-granted caller permissions fail at workflow-load time and later surface through grid-health as Stale. Extra scopes are allowed only when another job in the same workflow needs them; prefer least privilege.
+`pr-core.yml` callers need an explicit top-level or job-level permissions block that grants `contents: read`, `checks: write`, `pull-requests: write`, `security-events: write`, and `issues: write`. `issues: write` is part of the baseline because PR metadata/size checks maintain labels and comments. Under `workflow_call`, the callee declaration is documentary, so missing or under-granted caller permissions fail at workflow-load time and later surface through grid-health as Stale. Extra scopes are allowed only when another job in the same workflow needs them; prefer least privilege.
 
 
 ## Grid Review Request Workflow

--- a/docs/consumer-usage.md
+++ b/docs/consumer-usage.md
@@ -2,8 +2,37 @@
 
 This document provides sample workflows for consuming repos to adopt the HoneyDrunk.Actions workflow families.
 
+> Authoritative per ADR-0012 D9 (Decision: caller-workflow scaffolding is documented here). The canonical baselines below are the source of truth for invariant 39 (caller-workflow `permissions:` superset rule).
+
+## Caller permissions — the load-bearing rule
+
+Every caller workflow that consumes a reusable workflow from `HoneyDrunk.Actions` must declare a top-level `permissions:` block. Under `workflow_call`, the callee's `permissions:` block is purely documentary — the effective job token permissions are determined by the **caller**. A caller that omits `permissions:` inherits the repository's default token scope (`contents: read`, all writes `none` in the default GitHub Actions configuration), and any reusable workflow that requests a `write` scope fails at workflow-load time with a validation error, before a single step runs.
+
+This rule is invariant 39 in `HoneyDrunk.Architecture/constitution/invariants.md` and is governed by ADR-0012 D5.
+
+**Validation failure is silent until the next scheduled run.** If you add a new caller without `permissions:`, your PR may merge cleanly (the workflow-load check runs at trigger time, not at merge time). The grid-health aggregator (`grid-health-report.yml`) classifies the workflow as **Stale** when its scheduled trigger fails to produce a run, surfacing the bug within ~24 hours. The review agent's Request Changes rule (per `.claude/agents/review.md`) is the earlier safety net.
+
+The canonical permissions baselines below are minimum sets. Granting more than required is legal but discouraged. Granting less is broken at workflow-load time.
+
+| Reusable workflow | Minimum caller `permissions:` |
+|---|---|
+| `pr-core.yml` | `contents: read`, `pull-requests: write`, `checks: write`, `security-events: write`, `issues: write` |
+| `pr-sdk.yml` | `contents: read`, `pull-requests: write`, `checks: write`, `security-events: write` |
+| `job-review-request.yml` | `contents: read`, `pull-requests: read`, `issues: write` |
+| `release.yml` | `contents: read`, `packages: write`, `id-token: write`, `security-events: write` |
+| `job-deploy-container.yml` | `contents: read`, `id-token: write` |
+| `job-deploy-container-app.yml` | `contents: read`, `id-token: write` |
+| `job-deploy-function.yml` | `contents: read`, `id-token: write` |
+| `nightly-security.yml` | `contents: read`, `security-events: write`, `issues: write` |
+| `nightly-deps.yml` | `contents: write`, `pull-requests: write`, `issues: write` |
+| `nightly-accessibility.yml` | `contents: read`, `issues: write` |
+| `weekly-governance.yml` | `contents: read`, `issues: write` |
+
+For workflows not explicitly listed in ADR-0012 D5, the baseline is derived from the callee workflow's declared top-level and job-level `permissions:` blocks in `.github/workflows/<callee>.yml`.
+
 ## Table of Contents
 
+- [Caller permissions — the load-bearing rule](#caller-permissions--the-load-bearing-rule)
 - [PR Core Workflow](#pr-core-workflow)
 - [PR SDK Workflow](#pr-sdk-workflow)
 - [Grid Review Request Workflow](#grid-review-request-workflow)
@@ -202,6 +231,11 @@ jobs:
 
 ---
 
+### Permissions
+
+`pr-core.yml` callers need an explicit top-level or job-level permissions block that grants `contents: read`, `checks: write`, `pull-requests: write`, and `security-events: write`; examples that enable metadata/size label management also grant `issues: write`. Under `workflow_call`, the callee declaration is documentary, so missing or under-granted caller permissions fail at workflow-load time and later surface through grid-health as Stale. Extra scopes are allowed only when another job in the same workflow needs them; prefer least privilege.
+
+
 ## Grid Review Request Workflow
 
 **Purpose:** Advisory ADR-0044 trigger rail for the OpenClaw/Codex Grid Review Runner. This workflow does **not** run Codex, Anthropic, OpenAI, or any model API in GitHub Actions. It emits a signed review-request payload for OpenClaw, preserves the same payload as a durable fallback artifact, and can post a machine-readable replay pointer comment when OpenClaw is unavailable.
@@ -260,6 +294,11 @@ owner/repo#pr@headSha
 When webhook delivery is unavailable or not configured, the workflow uploads `review-request.json` as an artifact and can post a machine-readable PR comment containing the run id, run attempt, artifact name, head SHA, and idempotency key for OpenClaw cron/poll replay. The workflow is advisory only and must not be made a required blocking check until the Grid explicitly changes ADR-0044's posture.
 
 ---
+
+### Permissions
+
+`job-review-request.yml` callers need `contents: read`, `pull-requests: read`, and `issues: write`. The issue write scope is used only for the optional fallback replay-pointer comment. Missing caller permissions fail before the reusable workflow runs; over-granting is legal but discouraged.
+
 
 ## PR SDK Workflow
 
@@ -325,6 +364,11 @@ jobs:
 
 ---
 
+### Permissions
+
+`pr-sdk.yml` callers need `contents: read`, `checks: write`, `pull-requests: write`, and `security-events: write`. These scopes cover PR annotations, summary comments, and CodeQL SARIF upload. The caller owns the effective token scope under `workflow_call`, so do not rely on the callee's `permissions:` block alone.
+
+
 ## Release Workflow
 
 **Purpose:** Comprehensive release validation and artifact publication.
@@ -341,6 +385,12 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  security-events: write
+
 jobs:
   release:
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/release.yml@main
@@ -349,11 +399,6 @@ jobs:
       nuget-source: 'https://api.nuget.org/v3/index.json'
     secrets:
       nuget-api-key: ${{ secrets.NUGET_API_KEY }}
-
-permissions:
-  contents: read
-  packages: write
-  id-token: write
 ```
 
 ### Container Application Release
@@ -365,6 +410,12 @@ on:
   push:
     tags:
       - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  security-events: write
 
 jobs:
   release:
@@ -379,11 +430,6 @@ jobs:
     secrets:
       container-registry-username: ${{ github.actor }}
       container-registry-password: ${{ secrets.GITHUB_TOKEN }}
-
-permissions:
-  contents: read
-  packages: write
-  id-token: write
 ```
 
 ### Full Release with NuGet and Container
@@ -419,6 +465,7 @@ permissions:
   contents: read
   packages: write
   id-token: write
+  security-events: write
 ```
 
 ### Worker / Deployable App Release
@@ -433,6 +480,12 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  security-events: write
+
 jobs:
   release:
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/release.yml@main
@@ -442,11 +495,6 @@ jobs:
       publish-projects: 'MyWorker/MyWorker.csproj;MyApi/MyApi.csproj'
       publish-runtime: 'linux-x64'
       publish-self-contained: false
-
-permissions:
-  contents: read
-  packages: write
-  id-token: write
 ```
 
 ### Container with Custom Build Context
@@ -460,6 +508,12 @@ on:
   push:
     tags:
       - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  security-events: write
 
 jobs:
   release:
@@ -477,14 +531,14 @@ jobs:
       azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
     secrets:
       nuget-api-key: ${{ secrets.NUGET_API_KEY }}
-
-permissions:
-  contents: read
-  packages: write
-  id-token: write
 ```
 
 ---
+
+### Permissions
+
+`release.yml` callers need `contents: read`, `packages: write`, `id-token: write`, and `security-events: write`. `id-token: write` enables Azure OIDC/SBOM attestation paths, `packages: write` covers package/container publication, and `security-events: write` covers SARIF upload from release-time scans. Missing scopes fail at workflow-load or upload time; broader scopes should be justified by adjacent jobs.
+
 
 ## Azure Authentication
 
@@ -635,6 +689,11 @@ The `azure/keyvault-fetch` action can be used independently in any workflow:
 
 ---
 
+### Permissions
+
+`job-deploy-container.yml` callers need `contents: read` and `id-token: write`, derived from the callee workflow's declared permissions. `id-token: write` is mandatory for Azure OIDC. Missing it fails before Azure login can run; grant no package or issue scopes unless another job in the same caller needs them.
+
+
 ## Deploy Azure Container App
 
 **Purpose:** Deploy a containerized Node to Azure Container Apps using ADR-0015 revision traffic shifting.
@@ -765,6 +824,11 @@ Secret name mapping:
 
 ---
 
+### Permissions
+
+`job-deploy-container-app.yml` callers need `contents: read` and `id-token: write`, derived from the callee workflow's declared permissions. The caller controls the effective OIDC token grant under `workflow_call`; missing `id-token: write` breaks deployment before any Azure command runs.
+
+
 ## Deploy Azure Function App
 
 **Purpose:** Deploy a .NET Azure Function App after building with `release.yml` or a custom build job.
@@ -849,6 +913,11 @@ permissions:
 
 ---
 
+### Permissions
+
+`job-deploy-function.yml` callers need `contents: read` and `id-token: write`, derived from the callee workflow's declared permissions. If a build job in the same workflow uploads artifacts, keep any extra scopes scoped to that job when possible.
+
+
 ## Nightly Security Workflow
 
 **Purpose:** Deep, comprehensive security scanning on a schedule.
@@ -908,6 +977,11 @@ permissions:
 ```
 
 ---
+
+### Permissions
+
+`nightly-security.yml` callers need `contents: read`, `security-events: write`, and `issues: write`. `security-events: write` uploads SARIF; `issues: write` lets the workflow maintain tracking issues. Missing permissions cause scheduled runs to fail at workflow-load time, which grid-health later classifies as Stale.
+
 
 ## Nightly Dependencies Workflow
 
@@ -975,6 +1049,11 @@ permissions:
 ```
 
 ---
+
+### Permissions
+
+`nightly-deps.yml` callers need `contents: write`, `pull-requests: write`, and `issues: write`. Contents and pull-request writes are required when update PR creation is enabled; issues write maintains the dependency tracking issue. Report-only callers may not need every write path at runtime, but the canonical scaffold grants the reusable workflow's full supported surface so toggling `create-update-prs` does not require a permissions edit.
+
 
 ## Nightly Accessibility Workflow
 
@@ -1066,6 +1145,11 @@ permissions:
 
 ---
 
+### Permissions
+
+`nightly-accessibility.yml` callers need `contents: read` and `issues: write`, derived from the callee workflow's declared permissions. Issues write is required when `create-tracking-issue` is enabled. Missing caller permissions fail at workflow-load time; extra scopes are discouraged.
+
+
 ## Weekly Governance Workflow
 
 **Purpose:** Organization-wide governance checks for policy compliance.
@@ -1127,6 +1211,11 @@ permissions:
 
 ---
 
+### Permissions
+
+`weekly-governance.yml` callers need `contents: read` and `issues: write`, derived from the callee workflow's declared permissions. The org token may have broader repository access, but the workflow token should still be scoped to the minimum needed by the reusable workflow.
+
+
 ## Multi-Workflow Example
 
 Many repos will want to combine multiple workflows:
@@ -1145,6 +1234,15 @@ on:
   schedule:
     - cron: '0 2 * * *'  # Nightly security
   workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+  pull-requests: write
+  packages: write
+  id-token: write
+  security-events: write
+  issues: write
 
 jobs:
   # PR validation
@@ -1177,6 +1275,7 @@ permissions:
   checks: write
   pull-requests: write
   packages: write
+  id-token: write
   security-events: write
   issues: write
 ```
@@ -1230,6 +1329,13 @@ on:
 Use matrix strategy for multi-platform testing:
 
 ```yaml
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+  security-events: write
+  issues: write
+
 jobs:
   pr-validation-linux:
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main

--- a/docs/consumer-usage.md
+++ b/docs/consumer-usage.md
@@ -17,7 +17,7 @@ The canonical permissions baselines below are minimum sets. Granting more than r
 | Reusable workflow | Minimum caller `permissions:` |
 |---|---|
 | `pr-core.yml` | `contents: read`, `pull-requests: write`, `checks: write`, `security-events: write`, `issues: write` |
-| `pr-sdk.yml` | `contents: read`, `pull-requests: write`, `checks: write`, `security-events: write` |
+| `pr-sdk.yml` | `contents: read`, `pull-requests: write`, `checks: write`, `security-events: write`, `issues: write` |
 | `job-review-request.yml` | `contents: read`, `pull-requests: read`, `issues: write` |
 | `release.yml` | `contents: read`, `packages: write`, `id-token: write`, `security-events: write` |
 | `job-deploy-container.yml` | `contents: read`, `id-token: write` |
@@ -325,6 +325,7 @@ jobs:
       checks: write
       pull-requests: write
       security-events: write  # CodeQL SARIF upload
+      issues: write           # PR summary comments
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-sdk.yml@main
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -349,6 +350,7 @@ jobs:
       checks: write
       pull-requests: write
       security-events: write  # CodeQL SARIF upload
+      issues: write           # PR summary comments
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-sdk.yml@main
     with:
       dotnet-version: '10.0.x'
@@ -366,7 +368,7 @@ jobs:
 
 ### Permissions
 
-`pr-sdk.yml` callers need `contents: read`, `checks: write`, `pull-requests: write`, and `security-events: write`. These scopes cover PR annotations, summary comments, and CodeQL SARIF upload. The caller owns the effective token scope under `workflow_call`, so do not rely on the callee's `permissions:` block alone.
+`pr-sdk.yml` callers need `contents: read`, `checks: write`, `pull-requests: write`, `security-events: write`, and `issues: write`. These scopes cover PR annotations, PR summary comments, and CodeQL SARIF upload. The caller owns the effective token scope under `workflow_call`, so do not rely on the callee's `permissions:` block alone.
 
 
 ## Release Workflow

--- a/docs/d4-retrofit-audit.md
+++ b/docs/d4-retrofit-audit.md
@@ -1,0 +1,34 @@
+# D4 Direct-CLI Retrofit Audit
+
+ADR-0012 D4 requires reusable workflows to invoke tool CLIs directly instead of routing through third-party marketplace wrappers when the tool has a stable CLI. This audit records the current `uses:` surface in `HoneyDrunk.Actions` and the retrofit decisions made in the ADR-0012 rollout PR.
+
+## Audit table
+
+| Surface | Previous reference | Classification | ADR-0012 outcome |
+|---|---|---|---|
+| `.github/workflows/release.yml` container scan | `aquasecurity/trivy-action@0.35.0` | Third-party marketplace wrapper around stable Trivy CLI | Migrated to direct `docker run aquasec/trivy:0.69.3 image ...` invocation. |
+| `.github/workflows/release.yml` SBOM generation | `anchore/sbom-action@v0` | Third-party marketplace wrapper around stable Syft CLI | Migrated to direct Syft install + `syft dir:... --output spdx-json=...` invocation. |
+| `.github/workflows/actions-ci.yml` actionlint | `docker://rhysd/actionlint:1.7.12` | Docker image ref ambiguity under D4 | Outcome B chosen below; migrated to direct actionlint install + invocation. |
+
+First-party GitHub actions under `actions/*`, `github/codeql-action/*`, and Azure deployment/login actions remain permitted action references. Local composite actions (`./...`) and reusable workflow calls are outside the marketplace-wrapper concern.
+
+## Policy clarification — `docker://` image refs vs `run: docker run`
+
+ADR-0012 D4 forbids third-party marketplace wrappers but was silent on Docker-image refs (`uses: docker://owner/image:tag`). The actionlint step in `actions-ci.yml` surfaced that ambiguity.
+
+**Chosen outcome: Outcome B — `docker://` is forbidden; prefer install-and-invoke or explicit `run: docker run`.** Even though a `docker://` reference has less wrapper drift than a marketplace action, it still hides tool installation behind the GitHub `uses:` mechanism and creates another permitted shape future contributors must reason about. The canonical D4 forms are:
+
+1. install the tool binary in a `run:` step at a pinned version, then invoke it directly; or
+2. invoke a pinned tool image explicitly with `run: docker run ...` when containerized execution is the clearer operational shape.
+
+New uses of `docker://` are forbidden in `HoneyDrunk.Actions`. Existing uses are migrated. The actionlint migration preserves the previous flags exactly: `-color -shellcheck=`.
+
+## Conclusion
+
+The three known D4 retrofit findings from ADR-0012 are addressed in this PR. Future wrapper findings should be filed as small D4 retrofit packets and should update `docs/action-pins.md` when they add, remove, or change a third-party `uses:` pin.
+
+## Cross-references
+
+- HoneyDrunk.Architecture invariant 38 — reusable workflows invoke tool CLIs directly.
+- ADR-0012 D4 — direct CLI invocation policy.
+- ADR-0012 D10 — action-pin inventory.

--- a/docs/grid-health-aggregator.md
+++ b/docs/grid-health-aggregator.md
@@ -1,0 +1,33 @@
+# Grid Health Aggregator
+
+`grid-health-report.yml` is the ADR-0012 D6 runtime surface for Grid CI/CD health. It runs daily at `03:30 UTC` and can also be run manually with `workflow_dispatch`.
+
+The workflow reads `HoneyDrunk.Architecture/catalogs/grid-health.json`, requires schema version `>= 1.1`, polls each repo's `tracked_workflows`, and updates the stable `🕸️ Grid Health` issue in `HoneyDrunk.Actions`.
+
+## Classifications
+
+- **Pass** — latest relevant run succeeded inside the staleness window.
+- **Fail** — latest run failed, was cancelled, timed out, or needs action.
+- **Stale** — the workflow should have produced a recent run but did not.
+- **Missing** — the workflow is declared in the catalog but is absent or has never run.
+
+`weekly-*.yml` workflows use an eight-day staleness window. `nightly-*.yml` workflows use a twenty-eight-hour window. `publish.yml` has no staleness window because releases are event-driven.
+
+## How to read the issue
+
+Rows are repos. Columns are tracked workflows. Each non-empty cell links to the latest run when GitHub exposes one. Blank cells mean that workflow is not tracked for that repo.
+
+The `Catalog drift` section lists org repos missing from the Architecture catalog. That is not a workflow failure, but it means the aggregator cannot reason about the repo yet.
+
+## Manual re-run
+
+Open `HoneyDrunk.Actions` → Actions → `Grid Health Report` → **Run workflow**. The run requires `GRID_HEALTH_PAT`; missing or expired tokens fail fast before any issue body is updated.
+
+## Known-broken workflow policy
+
+There is no snooze mechanism today. If a workflow is known broken and intentionally deferred, close the per-repo issue with context; the next aggregator run will reopen it if the state is still red. That friction is intentional until the Grid decides a snooze contract.
+
+## References
+
+- ADR-0012 D6 — Grid Health aggregator.
+- HoneyDrunk.Architecture invariant 40 — Grid pipeline health is centrally visible.

--- a/docs/grid-health-aggregator.md
+++ b/docs/grid-health-aggregator.md
@@ -2,7 +2,9 @@
 
 `grid-health-report.yml` is the ADR-0012 D6 runtime surface for Grid CI/CD health. It runs daily at `03:30 UTC` and can also be run manually with `workflow_dispatch`.
 
-The workflow reads `HoneyDrunk.Architecture/catalogs/grid-health.json`, requires schema version `>= 1.1`, polls each repo's `tracked_workflows`, and updates the stable `🕸️ Grid Health` issue in `HoneyDrunk.Actions`.
+The workflow reads `HoneyDrunk.Architecture/catalogs/grid-health.json`, requires schema version `>= 1.1`, polls each repo's `tracked_workflows`, and updates the stable `Grid Health` issue in `HoneyDrunk.Actions`.
+
+`GRID_HEALTH_PAT` must be able to read `HoneyDrunk.Architecture`, read Actions workflow runs and org repo metadata, and write Issues in `HoneyDrunk.Actions` plus every repo with `tracked_workflows`. The Architecture checkout explicitly uses this token because the catalog repo may be private.
 
 ## Classifications
 

--- a/docs/grid-health-aggregator.md
+++ b/docs/grid-health-aggregator.md
@@ -27,7 +27,7 @@ Open `HoneyDrunk.Actions` → Actions → `Grid Health Report` → **Run workflo
 
 ## Known-broken workflow policy
 
-There is no snooze mechanism today. If a workflow is known broken and intentionally deferred, close the per-repo issue with context; the next aggregator run will reopen it if the state is still red. That friction is intentional until the Grid decides a snooze contract.
+There is no snooze mechanism today. If a workflow is known broken, missing, or intentionally deferred, close the per-repo issue with context; the next aggregator run will reopen it if the state is still red or missing. That friction is intentional until the Grid decides a snooze contract.
 
 ## References
 

--- a/scripts/grid-health-aggregator.sh
+++ b/scripts/grid-health-aggregator.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CATALOG_PATH="${1:?usage: grid-health-aggregator.sh <catalog-path>}"
+: "${GH_TOKEN:?GH_TOKEN must be set}"
+: "${GRID_HEALTH_TITLE:=🕸️ Grid Health}"
+: "${ACTIONS_REPO:=HoneyDrunkStudios/HoneyDrunk.Actions}"
+ORG="HoneyDrunkStudios"
+NOW_EPOCH="$(date -u +%s)"
+NOW_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+schema="$(jq -r '._meta.schema_version // "0.0"' "$CATALOG_PATH")"
+major="${schema%%.*}"
+minor="${schema#*.}"; minor="${minor%%.*}"
+if [ "${major:-0}" -lt 1 ] || { [ "${major:-0}" -eq 1 ] && [ "${minor:-0}" -lt 1 ]; }; then
+  cat >&2 <<EOF
+ERROR: catalogs/grid-health.json _meta.schema_version is "$schema", aggregator requires ">=1.1".
+tracked_workflows was introduced at schema 1.1 (packet 03 of the ADR-0012 rollout).
+Verify catalogs/grid-health.json has been updated and merged before running this aggregator.
+EOF
+  exit 1
+fi
+
+staleness_seconds() {
+  case "$1" in
+    publish.yml) echo 0 ;;
+    weekly-*.yml) echo $((8*24*60*60)) ;;
+    nightly-*.yml) echo $((28*60*60)) ;;
+    *) echo $((28*60*60)) ;;
+  esac
+}
+
+status_emoji() {
+  case "$1" in
+    Pass) echo "✅ Pass" ;;
+    Fail) echo "🔴 Fail" ;;
+    Stale) echo "🟠 Stale" ;;
+    Missing) echo "❓ Missing" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+json_escape() { jq -Rs .; }
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+results="$workdir/results.jsonl"
+: > "$results"
+
+mapfile -t repos < <(jq -c '.nodes[] | {id,name,signal,tracked_workflows:(.tracked_workflows // [])}' "$CATALOG_PATH")
+for row in "${repos[@]}"; do
+  name="$(jq -r '.name' <<<"$row")"
+  signal="$(jq -r '.signal' <<<"$row")"
+  count="$(jq '.tracked_workflows | length' <<<"$row")"
+  if [ "$count" -eq 0 ]; then
+    continue
+  fi
+  mapfile -t workflows < <(jq -r '.tracked_workflows[]' <<<"$row")
+  for workflow in "${workflows[@]}"; do
+    if [ "$workflow" = "pr-core.yml" ]; then
+      continue
+    fi
+    repo="$ORG/$name"
+    api="repos/$repo/actions/workflows/$workflow/runs?per_page=10"
+    body="$workdir/response.json"
+    response="$workdir/response.raw"
+    gh_status=0
+    gh api -i "$api" > "$response" 2>/dev/null || gh_status=$?
+    status_code="$(awk 'BEGIN{code=0} /^HTTP\//{code=$2} END{print code}' "$response")"
+    awk 'BEGIN{body=0} /^
+?$/{body=1; next} body{print}' "$response" > "$body"
+    classification="Missing"; url=""; created=""; conclusion=""
+    if [ "$status_code" = "200" ]; then
+      total="$(jq -r '.total_count // 0' "$body")"
+      if [ "$total" != "0" ]; then
+        latest="$(jq -c '.workflow_runs[0]' "$body")"
+        conclusion="$(jq -r '.conclusion // ""' <<<"$latest")"
+        created="$(jq -r '.created_at // ""' <<<"$latest")"
+        url="$(jq -r '.html_url // ""' <<<"$latest")"
+        if [[ "$conclusion" =~ ^(failure|cancelled|timed_out|action_required)$ ]]; then
+          classification="Fail"
+        elif [ "$workflow" = "publish.yml" ]; then
+          [ "$conclusion" = "success" ] && classification="Pass" || classification="Fail"
+        else
+          window="$(staleness_seconds "$workflow")"
+          created_epoch="$(date -u -d "$created" +%s 2>/dev/null || echo 0)"
+          age=$((NOW_EPOCH-created_epoch))
+          if [ "$conclusion" = "success" ] && [ "$age" -le "$window" ]; then
+            classification="Pass"
+          elif [ -z "$conclusion" ]; then
+            recent_success="$(jq -c '[.workflow_runs[] | select(.conclusion == "success")][0] // empty' "$body")"
+            if [ -n "$recent_success" ]; then
+              success_created="$(jq -r '.created_at' <<<"$recent_success")"
+              success_epoch="$(date -u -d "$success_created" +%s 2>/dev/null || echo 0)"
+              success_age=$((NOW_EPOCH-success_epoch))
+              if [ "$success_age" -le "$window" ]; then classification="Pass"; else classification="Stale"; fi
+            else
+              classification="Stale"
+            fi
+          else
+            classification="Stale"
+          fi
+        fi
+      fi
+    elif [ "$status_code" = "404" ]; then
+      classification="Missing"
+    else
+      echo "ERROR: gh api returned HTTP $status_code for $api" >&2
+      exit 1
+    fi
+    jq -nc --arg repo "$name" --arg workflow "$workflow" --arg status "$classification" --arg url "$url" --arg created "$created" --arg conclusion "$conclusion" '{repo:$repo,workflow:$workflow,status:$status,url:$url,created_at:$created,conclusion:$conclusion}' >> "$results"
+  done
+done
+
+workflows_json="$(jq -R -s 'split("\n")[:-1] | unique | sort' < <(jq -r '.workflow' "$results"))"
+fail_count="$(jq 'select(.status=="Fail") | 1' "$results" | wc -l | tr -d ' ')"
+stale_missing_count="$(jq 'select(.status=="Stale" or .status=="Missing") | 1' "$results" | wc -l | tr -d ' ')"
+if [ "$fail_count" -gt 0 ]; then header="🔴 $fail_count failures"; elif [ "$stale_missing_count" -gt 0 ]; then header="🟠 $stale_missing_count stale or missing"; else header="✅ all green"; fi
+
+org_repos="$workdir/org-repos.txt"
+gh api "orgs/$ORG/repos?per_page=100" --paginate --jq '.[].name' | sort > "$org_repos"
+catalog_repos="$workdir/catalog-repos.txt"
+jq -r '.nodes[].name' "$CATALOG_PATH" | sort > "$catalog_repos"
+drift="$(comm -23 "$org_repos" "$catalog_repos" || true)"
+if [ -n "$drift" ]; then header="$header · ⚠️ Catalog drift"; fi
+
+report="$workdir/report.md"
+{
+  echo "# $header"
+  echo
+  echo "Last updated: $NOW_ISO"
+  echo
+  echo "Legend: ✅ Pass · 🔴 Fail · 🟠 Stale · ❓ Missing · blank = workflow not tracked for that repo."
+  echo
+  printf '| Repo |'
+  jq -r '.[]' <<<"$workflows_json" | while read -r w; do printf ' `%s` |' "$w"; done
+  echo
+  printf '|---|'
+  jq -r '.[]' <<<"$workflows_json" | while read -r _; do printf '---|'; done
+  echo
+  jq -r '.nodes[] | select((.tracked_workflows // []) | length > 0) | .name' "$CATALOG_PATH" | while read -r repo; do
+    printf '| `%s` |' "$repo"
+    jq -r '.[]' <<<"$workflows_json" | while read -r workflow; do
+      cell="$(jq -r --arg repo "$repo" --arg workflow "$workflow" 'select(.repo==$repo and .workflow==$workflow) | @base64' "$results" | head -n1)"
+      if [ -z "$cell" ]; then printf ' |'; else
+        obj="$(printf '%s' "$cell" | base64 -d)"
+        st="$(jq -r '.status' <<<"$obj")"; url="$(jq -r '.url' <<<"$obj")"
+        label="$(status_emoji "$st")"
+        if [ -n "$url" ] && [ "$url" != "null" ]; then printf ' [%s](%s) |' "$label" "$url"; else printf ' %s |' "$label"; fi
+      fi
+    done
+    echo
+  done
+  echo
+  echo "## Per-repo failure issues"
+  echo
+  echo "Per-repo issues are opened for Fail/Stale and closed when the pair returns to Pass."
+  echo
+  echo "## Catalog drift"
+  echo
+  if [ -n "$drift" ]; then
+    echo "$drift" | sed 's/^/- ⚠️ Missing from `catalogs\/grid-health.json`: `/' | sed 's/$/`/'
+  else
+    echo "None."
+  fi
+} > "$report"
+
+find_issue() {
+  local repo="$1" title="$2"
+  gh issue list --repo "$repo" --state all --search "in:title \"$title\"" --json number,title,state --jq ".[] | select(.title == \"$title\") | .number" | head -n1
+}
+
+main_issue="$(find_issue "$ACTIONS_REPO" "$GRID_HEALTH_TITLE")"
+if [ -z "$main_issue" ]; then
+  main_issue="$(gh issue create --repo "$ACTIONS_REPO" --title "$GRID_HEALTH_TITLE" --body-file "$report" --label grid-health --json number --jq '.number')"
+else
+  gh issue reopen "$main_issue" --repo "$ACTIONS_REPO" >/dev/null 2>&1 || true
+  gh issue edit "$main_issue" --repo "$ACTIONS_REPO" --body-file "$report"
+fi
+
+jq -c 'select(.status=="Fail" or .status=="Stale")' "$results" | while read -r row; do
+  repo_name="$(jq -r '.repo' <<<"$row")"; workflow="$(jq -r '.workflow' <<<"$row")"; status="$(jq -r '.status' <<<"$row")"; url="$(jq -r '.url' <<<"$row")"; title="[grid-health] $workflow failing"
+  body="$workdir/failure.md"
+  printf 'Grid health classified `%s` in `%s` as **%s**.\n\nLatest run: %s\n\nUpdated: %s\n' "$workflow" "$repo_name" "$status" "${url:-none}" "$NOW_ISO" > "$body"
+  repo="$ORG/$repo_name"
+  issue="$(find_issue "$repo" "$title")"
+  if [ -z "$issue" ]; then gh issue create --repo "$repo" --title "$title" --body-file "$body" --label grid-health >/dev/null; else gh issue edit "$issue" --repo "$repo" --body-file "$body" >/dev/null; fi
+done
+
+jq -c 'select(.status=="Pass")' "$results" | while read -r row; do
+  repo_name="$(jq -r '.repo' <<<"$row")"; workflow="$(jq -r '.workflow' <<<"$row")"; url="$(jq -r '.url' <<<"$row")"; title="[grid-health] $workflow failing"; repo="$ORG/$repo_name"
+  issue="$(gh issue list --repo "$repo" --state open --search "in:title \"$title\"" --json number,title --jq ".[] | select(.title == \"$title\") | .number" | head -n1)"
+  if [ -n "$issue" ]; then gh issue close "$issue" --repo "$repo" --comment "Resolved by run $url at $NOW_ISO." >/dev/null; fi
+done
+
+cat "$report" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/grid-health-aggregator.sh
+++ b/scripts/grid-health-aggregator.sh
@@ -179,7 +179,7 @@ find_issue() {
 
 main_issue="$(find_issue "$ACTIONS_REPO" "$GRID_HEALTH_TITLE")"
 if [ -z "$main_issue" ]; then
-  main_issue_url="$(gh issue create --repo "$ACTIONS_REPO" --title "$GRID_HEALTH_TITLE" --body-file "$report" --label grid-health)"
+  main_issue_url="$(gh issue create --repo "$ACTIONS_REPO" --title "$GRID_HEALTH_TITLE" --body-file "$report")"
   main_issue="${main_issue_url##*/}"
 else
   gh issue reopen "$main_issue" --repo "$ACTIONS_REPO" >/dev/null 2>&1 || true
@@ -192,7 +192,7 @@ jq -c 'select(.status=="Fail" or .status=="Stale" or .status=="Missing")' "$resu
   printf 'Grid health classified `%s` in `%s` as **%s**.\n\nLatest run: %s\n\nUpdated: %s\n' "$workflow" "$repo_name" "$status" "${url:-none}" "$NOW_ISO" > "$body"
   repo="$ORG/$repo_name"
   issue="$(find_issue "$repo" "$title")"
-  if [ -z "$issue" ]; then gh issue create --repo "$repo" --title "$title" --body-file "$body" --label grid-health >/dev/null; else gh issue edit "$issue" --repo "$repo" --body-file "$body" >/dev/null; fi
+  if [ -z "$issue" ]; then gh issue create --repo "$repo" --title "$title" --body-file "$body" >/dev/null; else gh issue edit "$issue" --repo "$repo" --body-file "$body" >/dev/null; fi
 done
 
 jq -c 'select(.status=="Pass")' "$results" | while read -r row; do

--- a/scripts/grid-health-aggregator.sh
+++ b/scripts/grid-health-aggregator.sh
@@ -46,11 +46,10 @@ trap 'rm -rf "$workdir"' EXIT
 results="$workdir/results.jsonl"
 : > "$results"
 
-mapfile -t repos < <(jq -c '.nodes[] | {id,name,signal,tracked_workflows:(.tracked_workflows // [])}' "$CATALOG_PATH")
+mapfile -t repos < <(jq -c '.nodes[] | {id,name,tracked_workflows:(.tracked_workflows // [])}' "$CATALOG_PATH")
 for row in "${repos[@]}"; do
   name="$(jq -r '.name' <<<"$row")"
   name="${name//$'\r'/}"
-  signal="$(jq -r '.signal' <<<"$row")"
   count="$(jq '.tracked_workflows | length' <<<"$row")"
   if [ "$count" -eq 0 ]; then
     continue
@@ -66,8 +65,14 @@ for row in "${repos[@]}"; do
     body="$workdir/response.json"
     response="$workdir/response.raw"
     gh_status=0
-    gh api -i "$api" > "$response" 2>/dev/null || gh_status=$?
+    gh_error="$workdir/response.err"
+    gh api -i "$api" > "$response" 2>"$gh_error" || gh_status=$?
     status_code="$(awk 'BEGIN{code=0} /^HTTP\//{code=$2} END{print code}' "$response")"
+    if [ "$gh_status" -ne 0 ] && [ "$status_code" = "0" ]; then
+      echo "ERROR: gh api failed before returning headers for $api (exit $gh_status)." >&2
+      if [ -s "$gh_error" ]; then cat "$gh_error" >&2; fi
+      exit 1
+    fi
     awk 'BEGIN{body=0} /^\r?$/{body=1; next} body{print}' "$response" > "$body"
     classification="Missing"; url=""; created=""; conclusion=""
     if [ "$status_code" = "200" ]; then
@@ -167,7 +172,9 @@ report="$workdir/report.md"
 
 find_issue() {
   local repo="$1" title="$2"
-  gh issue list --repo "$repo" --state all --search "in:title \"$title\"" --json number,title,state --jq ".[] | select(.title == \"$title\") | .number" | head -n1
+  gh issue list --repo "$repo" --state all --search "in:title \"$title\"" --json number,title,state \
+    | jq -r --arg title "$title" '.[] | select(.title == $title) | .number' \
+    | head -n1
 }
 
 main_issue="$(find_issue "$ACTIONS_REPO" "$GRID_HEALTH_TITLE")"
@@ -190,7 +197,9 @@ done
 
 jq -c 'select(.status=="Pass")' "$results" | while read -r row; do
   repo_name="$(jq -r '.repo' <<<"$row")"; workflow="$(jq -r '.workflow' <<<"$row")"; url="$(jq -r '.url' <<<"$row")"; title="[grid-health] $workflow failing"; repo="$ORG/$repo_name"
-  issue="$(gh issue list --repo "$repo" --state open --search "in:title \"$title\"" --json number,title --jq ".[] | select(.title == \"$title\") | .number" | head -n1)"
+  issue="$(gh issue list --repo "$repo" --state open --search "in:title \"$title\"" --json number,title \
+    | jq -r --arg title "$title" '.[] | select(.title == $title) | .number' \
+    | head -n1)"
   if [ -n "$issue" ]; then gh issue close "$issue" --repo "$repo" --comment "Resolved by run $url at $NOW_ISO." >/dev/null; fi
 done
 

--- a/scripts/grid-health-aggregator.sh
+++ b/scripts/grid-health-aggregator.sh
@@ -159,7 +159,7 @@ report="$workdir/report.md"
   echo
   echo "## Per-repo failure issues"
   echo
-  echo "Per-repo issues are opened for Fail/Stale and closed when the pair returns to Pass."
+  echo "Per-repo issues are opened for Fail/Stale/Missing and closed when the pair returns to Pass."
   echo
   echo "## Catalog drift"
   echo
@@ -186,8 +186,8 @@ else
   gh issue edit "$main_issue" --repo "$ACTIONS_REPO" --body-file "$report"
 fi
 
-jq -c 'select(.status=="Fail" or .status=="Stale")' "$results" | while read -r row; do
-  repo_name="$(jq -r '.repo' <<<"$row")"; workflow="$(jq -r '.workflow' <<<"$row")"; status="$(jq -r '.status' <<<"$row")"; url="$(jq -r '.url' <<<"$row")"; title="[grid-health] $workflow failing"
+jq -c 'select(.status=="Fail" or .status=="Stale" or .status=="Missing")' "$results" | while read -r row; do
+  repo_name="$(jq -r '.repo' <<<"$row")"; workflow="$(jq -r '.workflow' <<<"$row")"; status="$(jq -r '.status' <<<"$row")"; url="$(jq -r '.url' <<<"$row")"; title="[grid-health] $workflow unhealthy"
   body="$workdir/failure.md"
   printf 'Grid health classified `%s` in `%s` as **%s**.\n\nLatest run: %s\n\nUpdated: %s\n' "$workflow" "$repo_name" "$status" "${url:-none}" "$NOW_ISO" > "$body"
   repo="$ORG/$repo_name"
@@ -196,7 +196,7 @@ jq -c 'select(.status=="Fail" or .status=="Stale")' "$results" | while read -r r
 done
 
 jq -c 'select(.status=="Pass")' "$results" | while read -r row; do
-  repo_name="$(jq -r '.repo' <<<"$row")"; workflow="$(jq -r '.workflow' <<<"$row")"; url="$(jq -r '.url' <<<"$row")"; title="[grid-health] $workflow failing"; repo="$ORG/$repo_name"
+  repo_name="$(jq -r '.repo' <<<"$row")"; workflow="$(jq -r '.workflow' <<<"$row")"; url="$(jq -r '.url' <<<"$row")"; title="[grid-health] $workflow unhealthy"; repo="$ORG/$repo_name"
   issue="$(gh issue list --repo "$repo" --state open --search "in:title \"$title\"" --json number,title \
     | jq -r --arg title "$title" '.[] | select(.title == $title) | .number' \
     | head -n1)"

--- a/scripts/grid-health-aggregator.sh
+++ b/scripts/grid-health-aggregator.sh
@@ -67,7 +67,7 @@ for row in "${repos[@]}"; do
     gh_status=0
     gh_error="$workdir/response.err"
     gh api -i "$api" > "$response" 2>"$gh_error" || gh_status=$?
-    status_code="$(awk 'BEGIN{code=0} /^HTTP\//{code=$2} END{print code}' "$response")"
+    status_code="$(awk 'BEGIN{code=0} /^HTTP\//{code=$2} END{print code}' "$response" | tr -d '\r')"
     if [ "$gh_status" -ne 0 ] && [ "$status_code" = "0" ]; then
       echo "ERROR: gh api failed before returning headers for $api (exit $gh_status)." >&2
       if [ -s "$gh_error" ]; then cat "$gh_error" >&2; fi

--- a/scripts/grid-health-aggregator.sh
+++ b/scripts/grid-health-aggregator.sh
@@ -171,8 +171,8 @@ report="$workdir/report.md"
 } > "$report"
 
 find_issue() {
-  local repo="$1" title="$2"
-  gh issue list --repo "$repo" --state all --search "in:title \"$title\"" --json number,title,state \
+  local repo="$1" title="$2" state="${3:-all}"
+  gh issue list --repo "$repo" --state "$state" --limit 1000 --search "in:title \"$title\"" --json number,title,state \
     | jq -r --arg title "$title" '.[] | select(.title == $title) | .number' \
     | head -n1
 }
@@ -192,14 +192,12 @@ jq -c 'select(.status=="Fail" or .status=="Stale" or .status=="Missing")' "$resu
   printf 'Grid health classified `%s` in `%s` as **%s**.\n\nLatest run: %s\n\nUpdated: %s\n' "$workflow" "$repo_name" "$status" "${url:-none}" "$NOW_ISO" > "$body"
   repo="$ORG/$repo_name"
   issue="$(find_issue "$repo" "$title")"
-  if [ -z "$issue" ]; then gh issue create --repo "$repo" --title "$title" --body-file "$body" >/dev/null; else gh issue edit "$issue" --repo "$repo" --body-file "$body" >/dev/null; fi
+  if [ -z "$issue" ]; then gh issue create --repo "$repo" --title "$title" --body-file "$body" >/dev/null; else gh issue reopen "$issue" --repo "$repo" >/dev/null 2>&1 || true; gh issue edit "$issue" --repo "$repo" --body-file "$body" >/dev/null; fi
 done
 
 jq -c 'select(.status=="Pass")' "$results" | while read -r row; do
   repo_name="$(jq -r '.repo' <<<"$row")"; workflow="$(jq -r '.workflow' <<<"$row")"; url="$(jq -r '.url' <<<"$row")"; title="[grid-health] $workflow unhealthy"; repo="$ORG/$repo_name"
-  issue="$(gh issue list --repo "$repo" --state open --search "in:title \"$title\"" --json number,title \
-    | jq -r --arg title "$title" '.[] | select(.title == $title) | .number' \
-    | head -n1)"
+  issue="$(find_issue "$repo" "$title" open)"
   if [ -n "$issue" ]; then gh issue close "$issue" --repo "$repo" --comment "Resolved by run $url at $NOW_ISO." >/dev/null; fi
 done
 

--- a/scripts/grid-health-aggregator.sh
+++ b/scripts/grid-health-aggregator.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 CATALOG_PATH="${1:?usage: grid-health-aggregator.sh <catalog-path>}"
 : "${GH_TOKEN:?GH_TOKEN must be set}"
-: "${GRID_HEALTH_TITLE:=🕸️ Grid Health}"
+: "${GRID_HEALTH_TITLE:=Grid Health}"
 : "${ACTIONS_REPO:=HoneyDrunkStudios/HoneyDrunk.Actions}"
 ORG="HoneyDrunkStudios"
 NOW_EPOCH="$(date -u +%s)"
@@ -40,7 +40,6 @@ status_emoji() {
   esac
 }
 
-json_escape() { jq -Rs .; }
 
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
@@ -50,6 +49,7 @@ results="$workdir/results.jsonl"
 mapfile -t repos < <(jq -c '.nodes[] | {id,name,signal,tracked_workflows:(.tracked_workflows // [])}' "$CATALOG_PATH")
 for row in "${repos[@]}"; do
   name="$(jq -r '.name' <<<"$row")"
+  name="${name//$'\r'/}"
   signal="$(jq -r '.signal' <<<"$row")"
   count="$(jq '.tracked_workflows | length' <<<"$row")"
   if [ "$count" -eq 0 ]; then
@@ -57,6 +57,7 @@ for row in "${repos[@]}"; do
   fi
   mapfile -t workflows < <(jq -r '.tracked_workflows[]' <<<"$row")
   for workflow in "${workflows[@]}"; do
+    workflow="${workflow//$'\r'/}"
     if [ "$workflow" = "pr-core.yml" ]; then
       continue
     fi
@@ -67,8 +68,7 @@ for row in "${repos[@]}"; do
     gh_status=0
     gh api -i "$api" > "$response" 2>/dev/null || gh_status=$?
     status_code="$(awk 'BEGIN{code=0} /^HTTP\//{code=$2} END{print code}' "$response")"
-    awk 'BEGIN{body=0} /^
-?$/{body=1; next} body{print}' "$response" > "$body"
+    awk 'BEGIN{body=0} /^\r?$/{body=1; next} body{print}' "$response" > "$body"
     classification="Missing"; url=""; created=""; conclusion=""
     if [ "$status_code" = "200" ]; then
       total="$(jq -r '.total_count // 0' "$body")"
@@ -136,7 +136,7 @@ report="$workdir/report.md"
   jq -r '.[]' <<<"$workflows_json" | while read -r w; do printf ' `%s` |' "$w"; done
   echo
   printf '|---|'
-  jq -r '.[]' <<<"$workflows_json" | while read -r _; do printf '---|'; done
+  jq -r '.[]' <<<"$workflows_json" | while read -r _; do printf '%s' '---|'; done
   echo
   jq -r '.nodes[] | select((.tracked_workflows // []) | length > 0) | .name' "$CATALOG_PATH" | while read -r repo; do
     printf '| `%s` |' "$repo"
@@ -172,7 +172,8 @@ find_issue() {
 
 main_issue="$(find_issue "$ACTIONS_REPO" "$GRID_HEALTH_TITLE")"
 if [ -z "$main_issue" ]; then
-  main_issue="$(gh issue create --repo "$ACTIONS_REPO" --title "$GRID_HEALTH_TITLE" --body-file "$report" --label grid-health --json number --jq '.number')"
+  main_issue_url="$(gh issue create --repo "$ACTIONS_REPO" --title "$GRID_HEALTH_TITLE" --body-file "$report" --label grid-health)"
+  main_issue="${main_issue_url##*/}"
 else
   gh issue reopen "$main_issue" --repo "$ACTIONS_REPO" >/dev/null 2>&1 || true
   gh issue edit "$main_issue" --repo "$ACTIONS_REPO" --body-file "$report"
@@ -193,4 +194,8 @@ jq -c 'select(.status=="Pass")' "$results" | while read -r row; do
   if [ -n "$issue" ]; then gh issue close "$issue" --repo "$repo" --comment "Resolved by run $url at $NOW_ISO." >/dev/null; fi
 done
 
-cat "$report" >> "$GITHUB_STEP_SUMMARY"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  cat "$report" >> "$GITHUB_STEP_SUMMARY"
+else
+  cat "$report"
+fi

--- a/tests/grid-health-aggregator-smoke.sh
+++ b/tests/grid-health-aggregator-smoke.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+cat > "$workdir/catalog.json" <<'JSON'
+{
+  "_meta": { "schema_version": "1.1" },
+  "nodes": [
+    { "id": "pass", "name": "RepoPass", "signal": "ok", "tracked_workflows": ["weekly-health.yml"] },
+    { "id": "fail", "name": "RepoFail", "signal": "bad", "tracked_workflows": ["nightly-health.yml"] },
+    { "id": "empty", "name": "RepoEmpty", "signal": "empty", "tracked_workflows": ["weekly-empty.yml"] },
+    { "id": "missing", "name": "RepoMissing", "signal": "missing", "tracked_workflows": ["publish.yml"] }
+  ]
+}
+JSON
+
+mkdir -p "$workdir/bin"
+cat > "$workdir/bin/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+log="${GRID_HEALTH_FAKE_GH_LOG:?}"
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  api)
+    include_headers=false
+    if [ "${1:-}" = "-i" ]; then include_headers=true; shift; fi
+    endpoint="${1:-}"
+    case "$endpoint" in
+      orgs/HoneyDrunkStudios/repos*)
+        printf '%s\n' RepoPass RepoFail RepoEmpty RepoMissing RepoDrift
+        ;;
+      repos/HoneyDrunkStudios/RepoPass/actions/workflows/weekly-health.yml/runs*)
+        printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n{"total_count":1,"workflow_runs":[{"conclusion":"success","created_at":"2999-01-01T00:00:00Z","html_url":"https://example.test/pass"}]}'
+        ;;
+      repos/HoneyDrunkStudios/RepoFail/actions/workflows/nightly-health.yml/runs*)
+        printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n{"total_count":1,"workflow_runs":[{"conclusion":"failure","created_at":"2999-01-01T00:00:00Z","html_url":"https://example.test/fail"}]}'
+        ;;
+      repos/HoneyDrunkStudios/RepoEmpty/actions/workflows/weekly-empty.yml/runs*)
+        printf 'HTTP/2 200\r\ncontent-type: application/json\r\n\r\n{"total_count":0,"workflow_runs":[]}'
+        ;;
+      repos/HoneyDrunkStudios/RepoMissing/actions/workflows/publish.yml/runs*)
+        printf 'HTTP/2 404\r\ncontent-type: application/json\r\n\r\n{"message":"Not Found"}'
+        ;;
+      *)
+        echo "unexpected gh api endpoint: $endpoint" >&2
+        exit 9
+        ;;
+    esac
+    ;;
+  issue)
+    sub="${1:-}"; shift || true
+    case "$sub" in
+      list)
+        true
+        ;;
+      create)
+        printf 'issue create %s\n' "$*" >> "$log"
+        printf 'https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/issues/9001\n'
+        ;;
+      edit|reopen|close)
+        printf 'issue %s %s\n' "$sub" "$*" >> "$log"
+        ;;
+      *)
+        echo "unexpected gh issue subcommand: $sub" >&2
+        exit 9
+        ;;
+    esac
+    ;;
+  auth)
+    exit 0
+    ;;
+  *)
+    echo "unexpected gh command: $cmd" >&2
+    exit 9
+    ;;
+esac
+GH
+chmod +x "$workdir/bin/gh"
+
+export PATH="$workdir/bin:$PATH"
+export GH_TOKEN=fake-token
+export GRID_HEALTH_FAKE_GH_LOG="$workdir/gh.log"
+unset GITHUB_STEP_SUMMARY || true
+
+output="$workdir/output.md"
+"$repo_root/scripts/grid-health-aggregator.sh" "$workdir/catalog.json" > "$output"
+
+grep -q '# 🔴 1 failures' "$output"
+grep -q '`RepoPass`' "$output"
+grep -q '✅ Pass' "$output"
+grep -q '🔴 Fail' "$output"
+grep -q '❓ Missing' "$output"
+grep -q 'RepoDrift' "$output"
+grep -q 'issue create --repo HoneyDrunkStudios/HoneyDrunk.Actions' "$workdir/gh.log"
+grep -q 'issue create --repo HoneyDrunkStudios/RepoFail' "$workdir/gh.log"
+
+echo "grid-health aggregator smoke passed"

--- a/tests/grid-health-aggregator-smoke.sh
+++ b/tests/grid-health-aggregator-smoke.sh
@@ -96,5 +96,7 @@ grep -q '❓ Missing' "$output"
 grep -q 'RepoDrift' "$output"
 grep -q 'issue create --repo HoneyDrunkStudios/HoneyDrunk.Actions' "$workdir/gh.log"
 grep -q 'issue create --repo HoneyDrunkStudios/RepoFail' "$workdir/gh.log"
+grep -q 'issue create --repo HoneyDrunkStudios/RepoEmpty' "$workdir/gh.log"
+grep -q 'issue create --repo HoneyDrunkStudios/RepoMissing' "$workdir/gh.log"
 
 echo "grid-health aggregator smoke passed"


### PR DESCRIPTION
## Summary

Implements the Actions-side ADR-0012 rollout:

- adds `grid-health-report.yml` plus `scripts/grid-health-aggregator.sh` for the D6 Grid Health issue/report flow
- adds operator docs for the Grid Health aggregator
- refreshes `docs/consumer-usage.md` with ADR-0012 D5/D9 caller `permissions:` baselines
- adds `docs/action-pins.md` for ADR-0012 D10 action-pin tracking
- migrates D4 wrapper violations:
  - `anchore/sbom-action` -> direct `syft` CLI release-asset install/invocation
  - `aquasecurity/trivy-action` -> direct `docker run aquasec/trivy:0.69.3`
  - `docker://rhysd/actionlint` -> direct actionlint release-asset install/invocation
- records the D4 retrofit audit and docker:// Outcome B decision

## Packet traceability

ADR-0012 packet coverage:

- `generated/issue-packets/active/adr-0012-grid-cicd-control-plane/04-actions-grid-health-aggregator.md`
- `generated/issue-packets/active/adr-0012-grid-cicd-control-plane/05-actions-consumer-usage-refresh.md`
- `generated/issue-packets/active/adr-0012-grid-cicd-control-plane/06-actions-action-pins-inventory.md`
- `generated/issue-packets/active/adr-0012-grid-cicd-control-plane/07-actions-d4-retrofit-audit.md`
- `generated/issue-packets/active/adr-0012-grid-cicd-control-plane/07a-actions-trivy-direct-cli-migration.md`
- `generated/issue-packets/active/adr-0012-grid-cicd-control-plane/07b-actions-sbom-direct-cli-migration.md`
- `generated/issue-packets/active/adr-0012-grid-cicd-control-plane/07c-actions-actionlint-docker-ref-decision.md`

## Validation

- `git diff --check`
- `bash -n scripts/grid-health-aggregator.sh`
- `bash -n tests/grid-health-aggregator-smoke.sh`
- `bash tests/grid-health-aggregator-smoke.sh`
- static check confirmed removed/resolved review-risk refs:
  - `aquasecurity/trivy-action`
  - `anchore/sbom-action`
  - `docker://rhysd/actionlint`
  - `raw.githubusercontent` installer usage
  - `main/install.sh`
  - `download-actionlint.bash`

## Notes / prerequisites

- `grid-health-report.yml` requires `GRID_HEALTH_PAT` in `HoneyDrunk.Actions` that can read `HoneyDrunk.Architecture`, read Actions workflow runs/org repo metadata, and write Issues on `HoneyDrunk.Actions` plus managed Grid repos.
- First live aggregator run should be manually reviewed before relying on the scheduled report.
- The Architecture-side `catalogs/grid-health.json` schema 1.1 / `tracked_workflows` changes are intentionally not included in this PR per Oleg's request to exclude Architecture commits.
