### PR TITLE
fix(adr-0011): pass sonar.cs.opencover.reportsPaths via begin CLI flag

### DIFF
--- a/.github/workflows/job-sonarcloud.yml
+++ b/.github/workflows/job-sonarcloud.yml
@@ -223,14 +223,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.github-token || github.token }}
         shell: bash
         run: |
-          # Coverage report paths come from per-repo sonar-project.properties
-          # (sonar.cs.opencover.reportsPaths = **/coverage.opencover.xml) — not
-          # hard-coded here, so per-repo config can diverge cleanly if needed.
+          # SonarScanner for .NET reads sonar.* configuration via `/d:` CLI flags or
+          # MSBuild `<SonarQubeSetting>` items — NOT via `sonar-project.properties`
+          # (a generic SonarScanner CLI convention the .NET scanner rejects).
+          # The coverage report path must be passed explicitly here so the scanner
+          # imports the OpenCover report produced by the conversion step above.
+          # Per-repo overrides are possible via MSBuild `<SonarQubeSetting>` items
+          # in Directory.Build.props if a repo needs to diverge from the default.
           "${GITHUB_WORKSPACE}/.sonar/scanner/dotnet-sonarscanner" begin \
             /k:"${{ inputs.sonar-project-key }}" \
             /o:"${{ inputs.sonar-organization }}" \
             /d:sonar.host.url="${{ inputs.sonar-host-url }}" \
-            /d:sonar.token="${SONAR_TOKEN}"
+            /d:sonar.token="${SONAR_TOKEN}" \
+            /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
 
       - name: Build
         working-directory: ${{ inputs.working-directory }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `job-sonarcloud.yml`: re-add the `/d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"` flag to the `dotnet-sonarscanner begin` invocation. The earlier removal expected per-repo `sonar-project.properties` to provide the path, but `.properties` files are then rejected by SonarScanner for .NET and were deleted in the consumer onboarding PRs. With no `.properties` file and no CLI flag, the scanner had no way to find the converted OpenCover report — coverage silently never imported, undermining ADR-0011 D11's quality-gate intent. Now the flag is the default in the reusable workflow; per-repo overrides remain available via MSBuild `<SonarQubeSetting>` items in `Directory.Build.props`.
+
 ### Added
 
 - `job-sonarcloud.yml`: new tier-2 reusable workflow that runs SonarQube Cloud (formerly SonarCloud) static analysis on a .NET repo via `dotnet-sonarscanner`. Reuses the coverage artifact from `job-build-and-test.yml` (no double `dotnet test`), converts Cobertura → OpenCover via ReportGenerator before the scanner reads coverage (Sonar's native C# format), and reports the SonarQube Cloud quality gate as a PR check. Job-level `if:` guard enforces `pull_request` + `push:main` only as defence in depth for ADR-0011 D11 cost discipline. Inputs include `working-directory` (supports inner-subdir Pattern A layouts), `sonar-organization`, `sonar-project-key`, and `coverage-artifact-name`. Per ADR-0011 packet 02.


### PR DESCRIPTION
## Summary

Follow-up fix to PR #130. The `job-sonarcloud.yml` reusable workflow was converting Cobertura → OpenCover into `TestResults/coverage.opencover.xml` but the scanner had no configured way to find the file:

- The earlier `/d:sonar.cs.opencover.reportsPaths` CLI flag was removed in #130 expecting per-repo `sonar-project.properties` to provide it
- The 12 consumer onboarding PRs then deleted `sonar-project.properties` because **SonarScanner for .NET rejects** that file (it's a generic SonarScanner CLI convention)
- Result: scanner runs analysis but never imports coverage. SonarCloud Code Analysis passes today because new code is empty, but each project's coverage metric stays at 0 — undermining ADR-0011 D11's quality-gate intent

## Fix

Re-add the CLI flag in the `dotnet-sonarscanner begin` invocation. Per-repo overrides remain possible via MSBuild `<SonarQubeSetting>` items in `Directory.Build.props` if any repo needs to diverge from the default.

## Affects

All 11 consumer PRs (Transport, Audit, Vault, Auth, Web.Rest, Data, Notify, Pulse, Communications, AI, Observe). They reference `job-sonarcloud.yml@main` and will pick up the fix automatically on their next CI run after this merges.

Kernel #59 (already merged) is the one repo that ran without coverage during its initial gate evaluation. The next PR opened against Kernel main will run with coverage imported.

## Test plan

- [ ] `actionlint` passes via `actions-ci.yml`
- [ ] After merge, retrigger one consumer PR (e.g. Transport #34) and confirm SonarCloud's Overview now shows non-empty coverage

Refs: Reviewer feedback on Web.Rest #26; ADR-0011 D11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Authorship: agent-claude-code