### PR TITLE
fix(adr-0011): generate coverage on push:main runs where pr-core is skipped

### DIFF
--- a/.github/workflows/job-sonarcloud.yml
+++ b/.github/workflows/job-sonarcloud.yml
@@ -180,13 +180,13 @@ jobs:
           dotnet tool update dotnet-reportgenerator-globaltool --tool-path "${GITHUB_WORKSPACE}/.sonar/reportgenerator"
 
       - name: Download coverage artifact (if exists)
-        id: download-coverage
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.coverage-artifact-name }}
-          # Download into the caller's working-directory so the relative
-          # `**/coverage.*.xml` globs resolve against the same root the
-          # scanner runs from.
+          # Download into the caller's working-directory so the
+          # `**/coverage.cobertura.xml` lookup in the next step (and the
+          # `**/coverage.opencover.xml` glob passed to the scanner) both
+          # resolve against the same root the scanner runs from.
           path: ${{ inputs.working-directory }}/TestResults
         continue-on-error: true
 

--- a/.github/workflows/job-sonarcloud.yml
+++ b/.github/workflows/job-sonarcloud.yml
@@ -180,41 +180,15 @@ jobs:
           dotnet tool update dotnet-reportgenerator-globaltool --tool-path "${GITHUB_WORKSPACE}/.sonar/reportgenerator"
 
       - name: Download coverage artifact (if exists)
+        id: download-coverage
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.coverage-artifact-name }}
           # Download into the caller's working-directory so the relative
-          # `**/coverage.*.xml` globs in sonar-project.properties resolve
-          # against the same root the scanner runs from.
+          # `**/coverage.*.xml` globs resolve against the same root the
+          # scanner runs from.
           path: ${{ inputs.working-directory }}/TestResults
         continue-on-error: true
-
-      - name: Convert Cobertura coverage to OpenCover
-        working-directory: ${{ inputs.working-directory }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          # Find any Cobertura xml files dropped by the download step. Skip
-          # silently if none exist — first-onboarding runs and no-coverage-collected
-          # runs should still produce a quality-gate verdict (coverage just won't
-          # be imported on that run).
-          mapfile -t COBERTURA_FILES < <(find ./TestResults -name "coverage.cobertura.xml" 2>/dev/null || true)
-          if [ "${#COBERTURA_FILES[@]}" -eq 0 ]; then
-            echo "::notice::No coverage.cobertura.xml found in TestResults/ — SonarQube Cloud will run without coverage data."
-            exit 0
-          fi
-          echo "Converting ${#COBERTURA_FILES[@]} Cobertura report(s) to OpenCover format..."
-          REPORTS=$(IFS=';'; echo "${COBERTURA_FILES[*]}")
-          "${GITHUB_WORKSPACE}/.sonar/reportgenerator/reportgenerator" \
-            -reports:"${REPORTS}" \
-            -targetdir:./TestResults/opencover \
-            -reporttypes:OpenCover
-          # Place the converted report at a stable path discoverable by the
-          # `**/coverage.opencover.xml` glob in per-repo sonar-project.properties.
-          if [ -f ./TestResults/opencover/OpenCover.xml ]; then
-            mv ./TestResults/opencover/OpenCover.xml ./TestResults/coverage.opencover.xml
-            echo "OpenCover report written to TestResults/coverage.opencover.xml"
-          fi
 
       - name: Begin SonarQube Cloud analysis
         working-directory: ${{ inputs.working-directory }}
@@ -227,7 +201,7 @@ jobs:
           # MSBuild `<SonarQubeSetting>` items — NOT via `sonar-project.properties`
           # (a generic SonarScanner CLI convention the .NET scanner rejects).
           # The coverage report path must be passed explicitly here so the scanner
-          # imports the OpenCover report produced by the conversion step above.
+          # imports the OpenCover report produced by the conversion step below.
           # Per-repo overrides are possible via MSBuild `<SonarQubeSetting>` items
           # in Directory.Build.props if a repo needs to diverge from the default.
           "${GITHUB_WORKSPACE}/.sonar/scanner/dotnet-sonarscanner" begin \
@@ -246,6 +220,60 @@ jobs:
             dotnet build "${{ inputs.project-path }}" --configuration Release
           else
             dotnet build --configuration Release
+          fi
+
+      - name: Generate coverage (push:main fallback when no artifact was downloaded)
+        working-directory: ${{ inputs.working-directory }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # PR runs reuse the coverage artifact produced by the caller's pr-core
+          # job (per ADR-0011 D11 cost discipline — no double `dotnet test`).
+          # On push:main runs there is no pr-core (it's gated to pull_request),
+          # so no upstream test job runs, so no artifact exists. Without coverage
+          # here, the SonarCloud Overview dashboard's coverage metric stays 0%
+          # forever and the leak-period baseline has no coverage to compare against.
+          #
+          # If the download step produced Cobertura files, skip — PR path already
+          # has what it needs. Otherwise, run `dotnet test` with coverage collection
+          # ourselves so the main-branch analysis has real data to report.
+          if find ./TestResults -name "coverage.cobertura.xml" 2>/dev/null | head -1 | grep -q .; then
+            echo "::notice::Coverage artifact found from caller (likely a PR run with pr-core); skipping local test execution."
+            exit 0
+          fi
+          echo "::notice::No coverage artifact found (likely a push:main run); running tests with coverage so SonarCloud receives baseline data."
+          TEST_ARGS=("--collect" "XPlat Code Coverage" "--results-directory" "./TestResults" "--configuration" "Release" "--no-build")
+          if [ -n "${{ inputs.project-path }}" ]; then
+            dotnet test "${{ inputs.project-path }}" "${TEST_ARGS[@]}"
+          else
+            dotnet test "${TEST_ARGS[@]}"
+          fi
+
+      - name: Convert Cobertura coverage to OpenCover
+        working-directory: ${{ inputs.working-directory }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Find any Cobertura xml files — either downloaded from the caller's
+          # pr-core artifact (PR runs) or freshly generated by the fallback test
+          # step above (push:main runs). Skip silently if neither path produced
+          # any — analysis still proceeds without coverage in that edge case.
+          mapfile -t COBERTURA_FILES < <(find ./TestResults -name "coverage.cobertura.xml" 2>/dev/null || true)
+          if [ "${#COBERTURA_FILES[@]}" -eq 0 ]; then
+            echo "::notice::No coverage.cobertura.xml found in TestResults/ — SonarQube Cloud will run without coverage data."
+            exit 0
+          fi
+          echo "Converting ${#COBERTURA_FILES[@]} Cobertura report(s) to OpenCover format..."
+          REPORTS=$(IFS=';'; echo "${COBERTURA_FILES[*]}")
+          "${GITHUB_WORKSPACE}/.sonar/reportgenerator/reportgenerator" \
+            -reports:"${REPORTS}" \
+            -targetdir:./TestResults/opencover \
+            -reporttypes:OpenCover
+          # Place the converted report at a stable path discoverable by the
+          # `**/coverage.opencover.xml` glob passed to the scanner.
+          if [ -f ./TestResults/opencover/OpenCover.xml ]; then
+            mv ./TestResults/opencover/OpenCover.xml ./TestResults/coverage.opencover.xml
+            echo "OpenCover report written to TestResults/coverage.opencover.xml"
           fi
 
       - name: End SonarQube Cloud analysis

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `job-sonarcloud.yml`: add a coverage-generation fallback for `push:main` runs. PR runs reuse the coverage artifact published by the caller's `pr-core` job (cost-disciplined per ADR-0011 D11). On `push:main` runs there's no `pr-core` (it's gated to `pull_request`), so no upstream test job runs and no artifact exists — leaving the SonarCloud Overview dashboard coverage metric stuck at 0% and giving the leak-period baseline no coverage to compare against. New conditional step now runs `dotnet test --collect "XPlat Code Coverage" --no-build` only when no Cobertura is found from the download step. PR runs are unchanged (the conditional is a no-op when the artifact is present). Steps reordered: begin → build → (conditional test) → convert → end, so coverage is generated after build but before the scanner reads it.
+
 - `job-sonarcloud.yml`: re-add the `/d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"` flag to the `dotnet-sonarscanner begin` invocation. The earlier removal expected per-repo `sonar-project.properties` to provide the path, but `.properties` files are then rejected by SonarScanner for .NET and were deleted in the consumer onboarding PRs. With no `.properties` file and no CLI flag, the scanner had no way to find the converted OpenCover report — coverage silently never imported, undermining ADR-0011 D11's quality-gate intent. Now the flag is the default in the reusable workflow; per-repo overrides remain available via MSBuild `<SonarQubeSetting>` items in `Directory.Build.props`.
 
 ### Added


### PR DESCRIPTION
## Summary

Follow-up to #132 (opencover reportsPaths flag fix). With that flag now passed, the scanner does try to read the OpenCover report — but on `push:main` runs there is no such report.

## Why

The original design had `job-sonarcloud.yml` reuse the coverage artifact published by the caller's `pr-core` job (cost-disciplined per ADR-0011 D11 — no double `dotnet test`). That works fine for PR runs. **But on `push:main` runs there is no `pr-core`** (it's gated to `pull_request` in the per-repo `pr.yml`), so no upstream test job runs, so no artifact exists. The download step fails (continue-on-error), the conversion step no-ops, and analysis runs without coverage data.

Net effect on the SonarCloud Overview dashboard for each onboarded repo:
- Coverage metric stuck at 0% forever
- Leak-period baseline has no coverage to compare against

That defeats the point of having `push:main` analysis at all (the whole reason we added the dual-event `if:` in the 11 consumer PRs + Kernel #60).

## Fix

Add a conditional `Generate coverage` step between `Build` and `Convert Cobertura → OpenCover`:

- **PR path** (download step produced Cobertura): skip — `pr-core` already ran tests
- **Push:main path** (no Cobertura from download): run `dotnet test --collect "XPlat Code Coverage" --no-build` so the scanner has real data to read

PR runs are unchanged. The conditional is a no-op when the artifact is present.

## Step ordering change

Previous: `download → convert → begin → build → end`
New:     `download → begin → build → (conditional test) → convert → end`

The new order is more conventional. The previous order only worked because conversion produced a file the scanner read at `end`; the new order is required by the conditional test which must run after build (so the `--no-build` flag works).

## Test plan

- [ ] `actionlint` passes
- [ ] After merge, retrigger one consumer PR (e.g. Transport #34) — PR path should be unchanged (artifact reused, no double-test)
- [ ] After consumer PR merges, observe the push:main run actually runs tests and uploads coverage to SonarCloud
- [ ] SonarCloud Overview for the project now shows non-zero coverage after the push:main analysis settles

Refs: Copilot review on HoneyDrunkStudios/HoneyDrunk.Kernel#60; SonarCloud docs (PR vs main-branch analysis); follow-up to #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Authorship: agent-claude-code