### PR TITLE
ci(adr-0012): bump Node 20 action pins

### DIFF
--- a/.github/actions/common/checkout-actions-repo/action.yml
+++ b/.github/actions/common/checkout-actions-repo/action.yml
@@ -15,7 +15,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout HoneyDrunk.Actions
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: HoneyDrunkStudios/HoneyDrunk.Actions
         path: ${{ inputs.path }}

--- a/.github/actions/common/generate-report-artifact/action.yml
+++ b/.github/actions/common/generate-report-artifact/action.yml
@@ -38,7 +38,7 @@ runs:
         echo "Artifact name: $NAME"
     
     - name: Upload report artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ steps.artifact-name.outputs.artifact_name }}
         path: ${{ inputs.report-directory }}/**/*

--- a/.github/actions/dotnet/setup/action.yml
+++ b/.github/actions/dotnet/setup/action.yml
@@ -49,7 +49,7 @@ runs:
         fi
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ steps.resolve-sdk.outputs.dotnet-version }}
         global-json-file: ${{ steps.resolve-sdk.outputs.global-json-file }}

--- a/.github/actions/nuget/setup-cache/action.yml
+++ b/.github/actions/nuget/setup-cache/action.yml
@@ -14,7 +14,7 @@ runs:
   using: 'composite'
   steps:
     - name: Cache NuGet packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.nuget/packages
         key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ hashFiles(format('{0}/**/*.csproj', inputs.working-directory)) }}

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install actionlint
         shell: bash

--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Architecture
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Architecture
           ref: ${{ inputs.architecture-ref }}
@@ -150,7 +150,7 @@ jobs:
 
       - name: Checkout target repo
         if: ${{ inputs.checkout-target != '' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ inputs.checkout-target }}
           token: ${{ secrets.github-token }}

--- a/.github/workflows/azure-oidc-deploy.yml
+++ b/.github/workflows/azure-oidc-deploy.yml
@@ -150,14 +150,14 @@ jobs:
 
       - name: Checkout HoneyDrunk.Actions
         if: ${{ inputs.check-sla }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           ref: ${{ steps.resolve-ref.outputs.ref }}
           path: .actions
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.artifact-path }}

--- a/.github/workflows/coverage-baseline-ratchet.yml
+++ b/.github/workflows/coverage-baseline-ratchet.yml
@@ -84,13 +84,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.github-token || github.token }}
           fetch-depth: 0
 
       - name: Download coverage reports artifact (if exists)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: coverage-reports-${{ inputs.runs-on }}
           path: TestResults

--- a/.github/workflows/file-packets.yml
+++ b/.github/workflows/file-packets.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Checkout HoneyDrunk.Architecture
         id: checkout-architecture
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ inputs.architecture-repo }}
           ref: ${{ steps.refs.outputs.architecture }}
@@ -132,7 +132,7 @@ jobs:
           persist-credentials: true
 
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           ref: ${{ steps.refs.outputs.actions }}

--- a/.github/workflows/grid-health-report.yml
+++ b/.github/workflows/grid-health-report.yml
@@ -23,10 +23,10 @@ jobs:
       ACTIONS_REPO: HoneyDrunkStudios/HoneyDrunk.Actions
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout Architecture catalog
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Architecture
           path: architecture

--- a/.github/workflows/hive-field-mirror.yml
+++ b/.github/workflows/hive-field-mirror.yml
@@ -106,7 +106,7 @@ jobs:
           fi
 
       - name: Checkout HoneyDrunk.Actions repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           ref: ${{ steps.resolve-ref.outputs.ref }}

--- a/.github/workflows/job-api-compatibility.yml
+++ b/.github/workflows/job-api-compatibility.yml
@@ -59,12 +59,12 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo

--- a/.github/workflows/job-build-and-test.yml
+++ b/.github/workflows/job-build-and-test.yml
@@ -62,10 +62,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -116,7 +116,7 @@ jobs:
         id: upload-tests
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results-${{ inputs.runs-on }}
           path: ${{ inputs.working-directory }}/TestResults/**/*
@@ -124,7 +124,7 @@ jobs:
       
       - name: Upload coverage reports
         if: ${{ inputs.collect-coverage }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-reports-${{ inputs.runs-on }}
           # Glob both Cobertura (consumed by coverage-baseline-ratchet.yml and

--- a/.github/workflows/job-codeql.yml
+++ b/.github/workflows/job-codeql.yml
@@ -112,10 +112,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -136,7 +136,7 @@ jobs:
           fi
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ inputs.languages }}
           queries: ${{ inputs.queries }}
@@ -167,7 +167,7 @@ jobs:
           dotnet build "$PROJECT" --no-incremental
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: ${{ inputs.category }}
           output: ${{ inputs.working-directory }}/codeql-results
@@ -179,7 +179,7 @@ jobs:
           sarif-dir: ${{ inputs.working-directory }}/codeql-results
 
       - name: Upload filtered SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ${{ inputs.working-directory }}/codeql-results
           category: ${{ inputs.category }}
@@ -280,7 +280,7 @@ jobs:
 
       - name: Upload SARIF artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sast-report
           path: ${{ inputs.working-directory }}/codeql-results/**/*.sarif

--- a/.github/workflows/job-coverage-analysis.yml
+++ b/.github/workflows/job-coverage-analysis.yml
@@ -58,12 +58,12 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Download coverage reports
         id: download
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.coverage-artifact-name }}
           path: ./coverage-reports
@@ -160,7 +160,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-analysis-results
           path: ./coverage-analysis/**/*

--- a/.github/workflows/job-dependency-scan.yml
+++ b/.github/workflows/job-dependency-scan.yml
@@ -98,10 +98,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -272,7 +272,7 @@ jobs:
 
       - name: Upload vulnerability report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vulnerable-packages
           path: ${{ inputs.working-directory }}/security-reports/**/*

--- a/.github/workflows/job-deploy-container-app.yml
+++ b/.github/workflows/job-deploy-container-app.yml
@@ -186,7 +186,7 @@ jobs:
     steps:
       - name: Checkout caller repository
         if: ${{ inputs.build-context != '' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Resolve actions checkout ref
         id: resolve-ref
@@ -201,7 +201,7 @@ jobs:
           fi
 
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           ref: ${{ steps.resolve-ref.outputs.ref }}

--- a/.github/workflows/job-deploy-container.yml
+++ b/.github/workflows/job-deploy-container.yml
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           ref: ${{ inputs.actions-ref }}

--- a/.github/workflows/job-deploy-function.yml
+++ b/.github/workflows/job-deploy-function.yml
@@ -164,14 +164,14 @@ jobs:
 
     steps:
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           ref: ${{ inputs.actions-ref }}
           path: .actions
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.package-path }}

--- a/.github/workflows/job-review-request.yml
+++ b/.github/workflows/job-review-request.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Checkout repository
         if: ${{ steps.event.outputs.skip != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -311,7 +311,7 @@ jobs:
 
       - name: Upload fallback review request artifact
         if: ${{ steps.event.outputs.skip != 'true' && steps.gate.outputs.skip != 'true' && inputs.upload-fallback-artifact }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.artifact-name }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           path: review-request.json

--- a/.github/workflows/job-secret-scan.yml
+++ b/.github/workflows/job-secret-scan.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -130,7 +130,7 @@ jobs:
 
       - name: Upload scan artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: gitleaks-report
           path: gitleaks-report.json

--- a/.github/workflows/job-sonarcloud.yml
+++ b/.github/workflows/job-sonarcloud.yml
@@ -129,12 +129,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # SonarQube Cloud requires full git history for blame attribution
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
 
@@ -145,7 +145,7 @@ jobs:
           java-version: '17'
 
       - name: Cache SonarQube Cloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
@@ -153,7 +153,7 @@ jobs:
 
       - name: Cache SonarQube Cloud scanner
         id: cache-sonar-scanner
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # Scanner cached at workspace root so the absolute
           # $GITHUB_WORKSPACE/.sonar/scanner path resolves regardless of the
@@ -171,7 +171,7 @@ jobs:
           dotnet tool update dotnet-sonarscanner --tool-path "${GITHUB_WORKSPACE}/.sonar/scanner"
 
       - name: Download coverage artifact (if exists)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.coverage-artifact-name }}
           # Download into the caller's working-directory so the

--- a/.github/workflows/job-static-analysis.yml
+++ b/.github/workflows/job-static-analysis.yml
@@ -83,10 +83,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo

--- a/.github/workflows/nightly-accessibility.yml
+++ b/.github/workflows/nightly-accessibility.yml
@@ -133,10 +133,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -150,7 +150,7 @@ jobs:
       
       - name: Setup Node.js
         if: ${{ contains(inputs.build-type, 'npm') || contains(inputs.build-type, 'storybook') }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ inputs.node-version }}
       
@@ -205,7 +205,7 @@ jobs:
           ${{ inputs.build-command }}
       
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: built-application
           path: |
@@ -228,16 +228,16 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: built-application
           path: ./app
       
       - name: Setup Node.js (for accessibility tools)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ inputs.node-version }}
       
@@ -303,7 +303,7 @@ jobs:
           echo "Routes to scan: $ROUTES"
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -356,7 +356,7 @@ jobs:
           echo "Critical violations: $CRITICAL_COUNT"
       
       - name: Upload accessibility report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: accessibility-report
           path: ./accessibility-reports/**/*
@@ -370,16 +370,16 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Download accessibility report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: accessibility-report
           path: ./accessibility-reports
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -402,7 +402,7 @@ jobs:
     
     steps:
       - name: Download accessibility report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: accessibility-report
           path: ./accessibility-reports

--- a/.github/workflows/nightly-deps.yml
+++ b/.github/workflows/nightly-deps.yml
@@ -122,10 +122,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -184,7 +184,7 @@ jobs:
           output-directory: ./dependency-reports
       
       - name: Upload .NET dependency report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dotnet-dependency-report
           path: |
@@ -199,10 +199,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -222,7 +222,7 @@ jobs:
       
       - name: Setup Node.js
         if: steps.check-npm.outputs.has_npm == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ inputs.node-version }}
       
@@ -243,7 +243,7 @@ jobs:
       
       - name: Upload npm dependency report
         if: steps.check-npm.outputs.has_npm == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: npm-dependency-report
           path: |
@@ -262,17 +262,17 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets['github-token'] || github.token }}
       
       - name: Download dependency reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ./all-dependency-reports
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -286,7 +286,7 @@ jobs:
       
       - name: Setup Node.js
         if: ${{ inputs.check-npm-deps }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ inputs.node-version }}
       
@@ -311,15 +311,15 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Download all dependency reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ./all-dependency-reports
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -436,7 +436,7 @@ jobs:
           echo "Download artifacts for detailed dependency reports." >> $GITHUB_STEP_SUMMARY
       
       - name: Upload consolidated report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: consolidated-dependency-report
           path: ./consolidated-dependency-report.*

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -111,10 +111,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -188,7 +188,7 @@ jobs:
           EOF
       
       - name: Upload vulnerability report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vulnerability-report
           path: ${{ inputs.working-directory }}/security-reports/**/*
@@ -201,10 +201,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -225,7 +225,7 @@ jobs:
           fi
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: csharp
           queries: security-and-quality
@@ -247,7 +247,7 @@ jobs:
           dotnet build "$PROJECT" --no-incremental
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: nightly-sast
           output: ${{ inputs.working-directory }}/security-reports
@@ -259,7 +259,7 @@ jobs:
           sarif-dir: ${{ inputs.working-directory }}/security-reports
 
       - name: Upload filtered SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ${{ inputs.working-directory }}/security-reports
           category: nightly-sast
@@ -267,7 +267,7 @@ jobs:
 
       - name: Upload SAST report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sast-report
           path: ${{ inputs.working-directory }}/security-reports/**/*.sarif
@@ -280,12 +280,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Checkout HoneyDrunk.Actions (shared gitleaks config)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -365,7 +365,7 @@ jobs:
       - name: Upload secrets SARIF to GitHub Security
         if: always() && hashFiles('./security-reports/secrets-scan.sarif') != ''
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ./security-reports/secrets-scan.sarif
           category: nightly-secrets
@@ -394,7 +394,7 @@ jobs:
 
       - name: Upload secret scan report
         if: always() && hashFiles('./security-reports/secrets-scan.sarif') != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: secret-scan-report
           path: ./security-reports/secrets-scan.sarif
@@ -407,7 +407,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Detect IaC files
         id: detect
@@ -480,14 +480,14 @@ jobs:
       - name: Upload IaC SARIF to GitHub Security
         if: steps.detect.outputs.has_iac == 'true'
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ./security-reports/iac-trivy.sarif
           category: nightly-iac
       
       - name: Upload IaC scan report
         if: steps.detect.outputs.has_iac == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: iac-security-report
           path: ./security-reports/iac-trivy.sarif
@@ -501,10 +501,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Download all security reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ./all-security-reports
       
@@ -679,7 +679,7 @@ jobs:
           fi
       
       - name: Upload consolidated report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: consolidated-security-report
           path: ./consolidated-security-report.*

--- a/.github/workflows/pr-core.yml
+++ b/.github/workflows/pr-core.yml
@@ -226,7 +226,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Validate accessibility URL provided
         if: ${{ inputs.accessibility-url == '' }}
@@ -236,7 +236,7 @@ jobs:
           exit 1
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -432,7 +432,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -586,7 +586,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -779,26 +779,26 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
           ref: ${{ inputs.actions-ref }}
       
       - name: Download test results artifact (if exists)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: test-results-${{ inputs.runs-on }}
           path: TestResults
         continue-on-error: true
       
       - name: Download coverage reports artifact (if exists)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: coverage-reports-${{ inputs.runs-on }}
           path: TestResults

--- a/.github/workflows/pr-sdk.yml
+++ b/.github/workflows/pr-sdk.yml
@@ -243,10 +243,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -279,10 +279,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo

--- a/.github/workflows/refresh-hive-project-metadata.yml
+++ b/.github/workflows/refresh-hive-project-metadata.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Detect auth mode
         id: auth-mode

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,12 +194,12 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -255,7 +255,7 @@ jobs:
       
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results-release
           path: ${{ inputs.working-directory }}/TestResults/**/*
@@ -263,7 +263,7 @@ jobs:
           if-no-files-found: ignore
       
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-reports-release
           path: ${{ inputs.working-directory }}/TestResults/**/coverage.cobertura.xml
@@ -280,12 +280,12 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -390,7 +390,7 @@ jobs:
           fi
       
       - name: Upload SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sbom
           path: ${{ inputs.working-directory }}/artifacts/sbom.spdx.json
@@ -398,7 +398,7 @@ jobs:
       
       - name: Upload license report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: license-report
           path: ${{ inputs.working-directory }}/artifacts/license-report.json
@@ -413,12 +413,12 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -462,7 +462,7 @@ jobs:
           working-directory: ${{ inputs.working-directory }}
       
       - name: Upload packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: nuget-packages
           path: ${{ inputs.working-directory }}/artifacts/*.nupkg
@@ -476,12 +476,12 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -539,7 +539,7 @@ jobs:
           done
       
       - name: Upload published apps
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: published-apps
           path: ${{ inputs.working-directory }}/publish-output/
@@ -553,10 +553,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -641,13 +641,13 @@ jobs:
       - name: Upload container scan to GitHub Security
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: container-scan.sarif
 
       - name: Upload container scan artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: container-vulnerability-report
           path: container-scan.sarif
@@ -671,7 +671,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Validate smoke test inputs
         if: ${{ inputs.smoke-test-url == '' }}

--- a/.github/workflows/seed-labels-fanout.yml
+++ b/.github/workflows/seed-labels-fanout.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout HoneyDrunk.Actions labels source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           ref: ${{ inputs.labels-source-ref }}

--- a/.github/workflows/seed-labels.yml
+++ b/.github/workflows/seed-labels.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout HoneyDrunk.Actions labels source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           ref: ${{ inputs.labels-source-ref || 'main' }}

--- a/.github/workflows/weekly-governance.yml
+++ b/.github/workflows/weekly-governance.yml
@@ -127,7 +127,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Determine organization
         id: org
@@ -296,7 +296,7 @@ jobs:
           echo "Security policy check complete"
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -331,7 +331,7 @@ jobs:
           GH_TOKEN: ${{ secrets.github-token }}
       
       - name: Upload governance reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: governance-reports
           path: ./governance-reports/**/*
@@ -344,13 +344,13 @@ jobs:
     
     steps:
       - name: Download governance reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: governance-reports
           path: ./governance-reports
       
       - name: Checkout HoneyDrunk.Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           path: .github/actions-repo
@@ -401,7 +401,7 @@ jobs:
           GH_TOKEN: ${{ secrets.github-token }}
       
       - name: Upload consolidated report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: consolidated-governance-report
           path: ./consolidated-governance-report.*

--- a/docs/QUICK-REFERENCE.md
+++ b/docs/QUICK-REFERENCE.md
@@ -149,7 +149,7 @@ jobs:
 ### Pattern 4: Actions Only (Maximum Control)
 ```yaml
 steps:
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@v5
   - uses: ./.github/actions/dotnet/setup
   - uses: ./.github/actions/nuget/setup-cache
   - uses: ./.github/actions/dotnet/restore

--- a/docs/action-pins.md
+++ b/docs/action-pins.md
@@ -8,13 +8,13 @@ Any PR that adds, removes, or changes a `uses:` pin updates this file in the sam
 
 | Action | Current pin | Deprecation deadline | Status | Successor | Notes |
 |---|---|---|---|---|---|
-| actions/cache | v4 | 2026-09-16 | Deprecated-with-deadline | actions/cache@v5 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
-| actions/checkout | v4 | 2026-09-16 | Deprecated-with-deadline | actions/checkout@v5 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
+| actions/cache | v5 | none | Current | none | Bumped to Node 24 successor for ADR-0012 packet 09. |
+| actions/checkout | v5 | none | Current | none | Bumped to Node 24 successor for ADR-0012 packet 09. |
 | actions/create-github-app-token | v1 | unknown | Current | none | none |
-| actions/download-artifact | v4 | 2026-09-16 | Deprecated-with-deadline | actions/download-artifact@v5 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
-| actions/setup-dotnet | v4 | 2026-09-16 | Deprecated-with-deadline | actions/setup-dotnet@v5 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
-| actions/setup-node | v4 | 2026-09-16 | Deprecated-with-deadline | actions/setup-node@v5 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
-| actions/upload-artifact | v4 | 2026-09-16 | Deprecated-with-deadline | actions/upload-artifact@v5 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
+| actions/download-artifact | v7 | none | Current | none | Bumped to default Node 24 successor for ADR-0012 packet 09. |
+| actions/setup-dotnet | v5 | none | Current | none | Bumped to Node 24 successor for ADR-0012 packet 09. |
+| actions/setup-node | v5 | none | Current | none | Bumped to Node 24 successor for ADR-0012 packet 09. |
+| actions/upload-artifact | v6 | none | Current | none | Bumped to default Node 24 successor for ADR-0012 packet 09. |
 | anthropics/claude-code-action | v1 | unknown | Current | none | none |
 | azure/functions-action | v1 | unknown | Current | none | none |
 | azure/functions-action | v2 | unknown | Current | none | none |
@@ -23,9 +23,9 @@ Any PR that adds, removes, or changes a `uses:` pin updates this file in the sam
 | docker/login-action | v3 | unknown | Current | none | none |
 | docker/setup-buildx-action | v3 | unknown | Current | none | none |
 | EnricoMi/publish-unit-test-result-action | v2 | unknown | Current | none | none |
-| github/codeql-action/analyze | v3 | 2026-09-16 | Deprecated-with-deadline | github/codeql-action/analyze@v4 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
-| github/codeql-action/init | v3 | 2026-09-16 | Deprecated-with-deadline | github/codeql-action/init@v4 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
-| github/codeql-action/upload-sarif | v3 | 2026-09-16 | Deprecated-with-deadline | github/codeql-action/upload-sarif@v4 | Pinned action runs on Node 20; replace before GitHub removes Node 20 action runtime. |
+| github/codeql-action/analyze | v4 | none | Current | none | Bumped to Node 24 successor for ADR-0012 packet 09. |
+| github/codeql-action/init | v4 | none | Current | none | Bumped to Node 24 successor for ADR-0012 packet 09. |
+| github/codeql-action/upload-sarif | v4 | none | Current | none | Bumped to Node 24 successor for ADR-0012 packet 09. |
 | peter-evans/create-or-update-comment | v4 | unknown | Current | none | none |
 | peter-evans/create-pull-request | v6 | unknown | Current | none | none |
 | peter-evans/find-comment | v3 | unknown | Current | none | none |

--- a/docs/consumer-usage.md
+++ b/docs/consumer-usage.md
@@ -851,12 +851,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
       - run: dotnet publish MyProject.Functions/MyProject.Functions.csproj -c Release -o ./publish
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: function-app
           path: ./publish
@@ -1392,9 +1392,9 @@ jobs:
      build:
        runs-on: ubuntu-latest
        steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@v5
          - name: Setup .NET
-           uses: actions/setup-dotnet@v4
+           uses: actions/setup-dotnet@v5
          # ... many more steps
 
    # New


### PR DESCRIPTION
## Summary

- Bumps first-party GitHub Actions pins away from Node 20-runtime majors across reusable workflows and composite actions.
- Updates `docs/action-pins.md` in the same PR per ADR-0012 D10.
- Uses the currently appropriate artifact successors for default Node 24 behavior: `actions/upload-artifact@v6` and `actions/download-artifact@v7`.

Packet: HoneyDrunk.Architecture/generated/issue-packets/active/adr-0012-grid-cicd-control-plane/09-actions-node20-actions-bump.md

## Validation

- `git diff --check HEAD~1..HEAD`
- `rg --hidden -n "actions/(checkout|setup-dotnet|setup-node|cache)@v4|actions/upload-artifact@v[45]|actions/download-artifact@v[456]|github/codeql-action/(init|analyze|upload-sarif)@v3" .github docs` returned no matches.
- Checked current GitHub release notes for the Node 24 action successors before adjusting artifact pins.

## Authorship

Authorship: agent-codex

## Notes

- Post-merge smoke tests still need to be triggered for `nightly-security.yml` and `nightly-deps.yml` against a representative caller repo.