### PR TITLE
ci: add SonarQube new-code quality gate

### DIFF
--- a/.github/workflows/job-sonarcloud-quality-gate.yml
+++ b/.github/workflows/job-sonarcloud-quality-gate.yml
@@ -1,0 +1,326 @@
+# ==============================================================================
+# SonarQube Cloud Quality Gate Job (Tier 2)
+# ==============================================================================
+# Purpose:
+#   Poll SonarQube Cloud PR new-code metrics and fail or warn when the PR
+#   introduces issues beyond the configured thresholds.
+#
+# Tier:
+#   Tier 2 of the ADR-0011 PR review pipeline. This workflow complements
+#   job-sonarcloud.yml by enforcing thresholds that the free SonarQube Cloud
+#   "Sonar way" gate cannot customize for HoneyDrunk's public-repo posture.
+#
+# Caller contract:
+#   This workflow is workflow_call-only and is intended for pull_request runs.
+#   It reads PR measures from SonarQube Cloud using the same SONAR_TOKEN used by
+#   job-sonarcloud.yml. If SonarQube Cloud has not produced PR measures yet, the
+#   workflow reports a warning and exits 0 so fork PRs, token rotation gaps, or
+#   skipped upstream analysis do not create false hard failures.
+#
+# Phase-flip toggle point:
+#   Default mode is warn for ADR-0011 packet 08 soft launch. Flip caller input
+#   mode to enforce per repo after observing real PRs; flip the default here
+#   only when the Grid adopts enforce mode broadly.
+# ==============================================================================
+
+name: SonarQube Cloud Quality Gate (Job)
+
+on:
+  workflow_call:
+    inputs:
+      sonar-organization:
+        description: 'SonarQube Cloud organization key (e.g. honeydrunkstudios)'
+        required: true
+        type: string
+
+      sonar-project-key:
+        description: 'SonarQube Cloud project key (e.g. honeydrunkstudios_HoneyDrunk.Kernel)'
+        required: true
+        type: string
+
+      sonar-host-url:
+        description: 'SonarQube Cloud host URL'
+        required: false
+        type: string
+        default: 'https://sonarcloud.io'
+
+      mode:
+        description: 'Gate mode: warn (warnings-only) or enforce (fail PR)'
+        required: false
+        type: string
+        default: 'warn'
+
+      max-new-violations:
+        description: 'Maximum new_violations allowed'
+        required: false
+        type: number
+        default: 0
+
+      max-new-bugs:
+        description: 'Maximum new_bugs allowed'
+        required: false
+        type: number
+        default: 0
+
+      max-new-vulnerabilities:
+        description: 'Maximum new_vulnerabilities allowed'
+        required: false
+        type: number
+        default: 0
+
+      max-new-code-smells:
+        description: 'Maximum new_code_smells allowed'
+        required: false
+        type: number
+        default: 0
+
+      max-new-security-hotspots:
+        description: 'Maximum new_security_hotspots allowed'
+        required: false
+        type: number
+        default: 0
+
+      runs-on:
+        description: 'GitHub runner to use'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+
+    secrets:
+      sonar-token:
+        description: 'SONAR_TOKEN - same org secret used by job-sonarcloud.yml'
+        required: true
+
+    outputs:
+      verdict:
+        description: 'Quality-gate verdict for PR summaries'
+        value: ${{ jobs.sonar-quality-gate.outputs.verdict }}
+      gate_failed:
+        description: 'true when thresholds were breached'
+        value: ${{ jobs.sonar-quality-gate.outputs.gate_failed }}
+      breached_count:
+        description: 'Number of breached SonarQube Cloud metrics'
+        value: ${{ jobs.sonar-quality-gate.outputs.breached_count }}
+      breach_summary:
+        description: 'Human-readable breached metric summary'
+        value: ${{ jobs.sonar-quality-gate.outputs.breach_summary }}
+      summary_line:
+        description: 'One-line summary for PR comments'
+        value: ${{ jobs.sonar-quality-gate.outputs.summary_line }}
+
+permissions:
+  contents: read
+
+jobs:
+  sonar-quality-gate:
+    name: SonarQube Cloud Quality Gate
+    runs-on: ${{ inputs.runs-on }}
+    if: ${{ github.event_name == 'pull_request' }}
+    outputs:
+      verdict: ${{ steps.gate.outputs.verdict }}
+      gate_failed: ${{ steps.gate.outputs.gate_failed }}
+      breached_count: ${{ steps.gate.outputs.breached_count }}
+      breach_summary: ${{ steps.gate.outputs.breach_summary }}
+      summary_line: ${{ steps.gate.outputs.summary_line }}
+
+    steps:
+      - name: Fetch SonarQube Cloud measures and enforce thresholds
+        id: gate
+        env:
+          SONAR_TOKEN: ${{ secrets.sonar-token }}
+          SONAR_HOST_URL: ${{ inputs.sonar-host-url }}
+          SONAR_ORGANIZATION: ${{ inputs.sonar-organization }}
+          SONAR_PROJECT_KEY: ${{ inputs.sonar-project-key }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MODE: ${{ inputs.mode }}
+          MAX_NEW_VIOLATIONS: ${{ inputs.max-new-violations }}
+          MAX_NEW_BUGS: ${{ inputs.max-new-bugs }}
+          MAX_NEW_VULNERABILITIES: ${{ inputs.max-new-vulnerabilities }}
+          MAX_NEW_CODE_SMELLS: ${{ inputs.max-new-code-smells }}
+          MAX_NEW_SECURITY_HOTSPOTS: ${{ inputs.max-new-security-hotspots }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          import json
+          import os
+          import sys
+          import time
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          out_path = os.environ["GITHUB_OUTPUT"]
+
+          def emit(key, value):
+              value = "" if value is None else str(value)
+              with open(out_path, "a", encoding="utf-8") as out:
+                  if "\n" in value:
+                      out.write(f"{key}<<EOF\n{value}\nEOF\n")
+                  else:
+                      out.write(f"{key}={value}\n")
+
+          def finish(verdict, gate_failed, breached_count, breach_summary, summary_line, exit_code):
+              emit("verdict", verdict)
+              emit("gate_failed", "true" if gate_failed else "false")
+              emit("breached_count", breached_count)
+              emit("breach_summary", breach_summary)
+              emit("summary_line", summary_line)
+              with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+                  summary.write("### SonarQube Cloud Quality Gate\n\n")
+                  summary.write(summary_line + "\n")
+                  if breach_summary:
+                      summary.write("\nBreaches: " + breach_summary + "\n")
+              sys.exit(exit_code)
+
+          host = (os.environ.get("SONAR_HOST_URL") or "").rstrip("/")
+          org = (os.environ.get("SONAR_ORGANIZATION") or "").strip()
+          project_key = (os.environ.get("SONAR_PROJECT_KEY") or "").strip()
+          pr_number = (os.environ.get("PR_NUMBER") or "").strip()
+          mode = (os.environ.get("MODE") or "warn").strip().lower()
+          token = os.environ.get("SONAR_TOKEN") or ""
+
+          if mode not in {"warn", "enforce"}:
+              print(f"::error::Unknown SonarQube Cloud quality-gate mode '{mode}'. Expected 'warn' or 'enforce'.")
+              finish("configuration failed", True, 0, "", "SonarQube Cloud Quality Gate: configuration failed", 1)
+
+          if not host or not org or not project_key or not pr_number:
+              print("::error::sonar-host-url, sonar-organization, sonar-project-key, and PR number are required.")
+              finish("configuration failed", True, 0, "", "SonarQube Cloud Quality Gate: configuration failed", 1)
+
+          def threshold(name):
+              raw = os.environ.get(name, "0")
+              try:
+                  value = int(float(raw))
+              except (TypeError, ValueError):
+                  print(f"::error::{name} must be numeric, got '{raw}'.")
+                  finish("configuration failed", True, 0, "", "SonarQube Cloud Quality Gate: configuration failed", 1)
+              if value < 0:
+                  print(f"::error::{name} must be >= 0, got {value}.")
+                  finish("configuration failed", True, 0, "", "SonarQube Cloud Quality Gate: configuration failed", 1)
+              return value
+
+          metrics = [
+              ("new_violations", threshold("MAX_NEW_VIOLATIONS")),
+              ("new_bugs", threshold("MAX_NEW_BUGS")),
+              ("new_vulnerabilities", threshold("MAX_NEW_VULNERABILITIES")),
+              ("new_code_smells", threshold("MAX_NEW_CODE_SMELLS")),
+              ("new_security_hotspots", threshold("MAX_NEW_SECURITY_HOTSPOTS")),
+          ]
+
+          query = urllib.parse.urlencode({
+              "organization": org,
+              "component": project_key,
+              "pullRequest": pr_number,
+              "metricKeys": ",".join(metric for metric, _ in metrics),
+          })
+          url = f"{host}/api/measures/component?{query}"
+          summary_url = (
+              f"{host}/summary/new_code?"
+              + urllib.parse.urlencode({"id": project_key, "pullRequest": pr_number, "organization": org})
+          )
+
+          headers = {
+              "Authorization": f"Bearer {token}",
+              "Accept": "application/json",
+          }
+
+          values = {}
+          last_error = ""
+          fatal_error = ""
+          for attempt in range(1, 7):
+              try:
+                  request = urllib.request.Request(url, headers=headers)
+                  with urllib.request.urlopen(request, timeout=10) as response:
+                      payload = json.loads(response.read().decode("utf-8"))
+                  measures = (payload.get("component") or {}).get("measures") or []
+                  values = {
+                      measure.get("metric"): (measure.get("period") or {}).get("value")
+                      for measure in measures
+                      if measure.get("metric")
+                  }
+                  if values:
+                      break
+                  last_error = "no measures returned yet"
+                  print(f"::notice::SonarQube Cloud API attempt {attempt} returned no PR measures yet.")
+              except urllib.error.HTTPError as exc:
+                  body = exc.read().decode("utf-8", errors="replace")
+                  last_error = f"HTTP {exc.code}: {body[:300]}"
+                  if exc.code in {400, 401, 403, 404}:
+                      fatal_error = last_error
+                      break
+                  print(f"::notice::SonarQube Cloud API attempt {attempt} failed: {last_error}")
+              except Exception as exc:
+                  last_error = str(exc)
+                  print(f"::notice::SonarQube Cloud API attempt {attempt} failed: {last_error}")
+
+              if attempt < 6:
+                  time.sleep(5)
+
+          if fatal_error:
+              message = (
+                  "SonarQube Cloud Quality Gate: failed - SonarQube Cloud "
+                  f"configuration or authorization error ({fatal_error}). "
+                  f"See {summary_url}"
+              )
+              print(f"::error::{message}")
+              finish("configuration failed", True, 0, "", message, 1)
+
+          if not values:
+              message = (
+                  "SonarQube Cloud Quality Gate: skipped - PR measures were not "
+                  f"available after retries ({last_error or 'unknown reason'}). "
+                  f"See {summary_url}"
+              )
+              print(f"::warning::{message}")
+              finish("skipped (measures unavailable)", False, 0, "", message, 0)
+
+          failures = []
+          observed = []
+          for metric, limit in metrics:
+              raw = values.get(metric)
+              if raw is None:
+                  continue
+              try:
+                  actual = int(float(raw))
+              except (TypeError, ValueError):
+                  print(f"::notice::Ignoring non-numeric SonarQube metric {metric}={raw!r}.")
+                  continue
+              observed.append(f"{metric}={actual}")
+              if actual > limit:
+                  failures.append((metric, actual, limit))
+
+          if not observed:
+              message = (
+                  "SonarQube Cloud Quality Gate: skipped - configured new-code "
+                  f"metrics were not present in the PR analysis. See {summary_url}"
+              )
+              print(f"::warning::{message}")
+              finish("skipped (metrics unavailable)", False, 0, "", message, 0)
+
+          if not failures:
+              detail = ", ".join(observed)
+              message = f"SonarQube Cloud Quality Gate: passed ({detail}). See {summary_url}"
+              print(f"::notice::{message}")
+              finish("passed", False, 0, "", message, 0)
+
+          breach_summary = "; ".join(
+              f"{metric}={actual} (threshold {limit})"
+              for metric, actual, limit in failures
+          )
+          for metric, actual, limit in failures:
+              print(f"::error::SonarQube Cloud new-code breach: {metric}={actual} (threshold {limit})")
+          print(f"::error::See SonarQube Cloud PR summary: {summary_url}")
+
+          verdict = f"{'failed' if mode == 'enforce' else 'warn'} - {breach_summary}"
+          message = (
+              f"SonarQube Cloud Quality Gate: {verdict}. "
+              f"Mode: {mode}. See {summary_url}"
+          )
+
+          if mode == "enforce":
+              finish(verdict, True, len(failures), breach_summary, message, 1)
+
+          print("::warning::Gate mode is warn; reporting breaches without failing the PR.")
+          finish(verdict, True, len(failures), breach_summary, message, 0)
+          PY

--- a/.github/workflows/pr-core.yml
+++ b/.github/workflows/pr-core.yml
@@ -97,6 +97,60 @@ on:
         type: string
         default: 'note'
 
+      enable-sonar-quality-gate:
+        description: 'Poll SonarQube Cloud PR new-code metrics and apply ADR-0011 D11 thresholds'
+        required: false
+        type: boolean
+        default: false
+
+      sonar-quality-gate-mode:
+        description: 'Mode for the SonarQube Cloud quality gate: warn or enforce'
+        required: false
+        type: string
+        default: 'warn'
+
+      sonar-organization:
+        description: 'SonarQube Cloud organization key (required when enable-sonar-quality-gate is true)'
+        required: false
+        type: string
+        default: ''
+
+      sonar-project-key:
+        description: 'SonarQube Cloud project key (required when enable-sonar-quality-gate is true)'
+        required: false
+        type: string
+        default: ''
+
+      sonar-max-new-violations:
+        description: 'Maximum new_violations allowed by the SonarQube Cloud quality gate'
+        required: false
+        type: number
+        default: 0
+
+      sonar-max-new-bugs:
+        description: 'Maximum new_bugs allowed by the SonarQube Cloud quality gate'
+        required: false
+        type: number
+        default: 0
+
+      sonar-max-new-vulnerabilities:
+        description: 'Maximum new_vulnerabilities allowed by the SonarQube Cloud quality gate'
+        required: false
+        type: number
+        default: 0
+
+      sonar-max-new-code-smells:
+        description: 'Maximum new_code_smells allowed by the SonarQube Cloud quality gate'
+        required: false
+        type: number
+        default: 0
+
+      sonar-max-new-security-hotspots:
+        description: 'Maximum new_security_hotspots allowed by the SonarQube Cloud quality gate'
+        required: false
+        type: number
+        default: 0
+
       enable-accessibility-check:
         description: 'Run minimal accessibility check (opt-in)'
         required: false
@@ -136,6 +190,9 @@ on:
     secrets:
       github-token:
         description: 'GitHub token for PR comments and API access'
+        required: false
+      sonar-token:
+        description: 'SONAR_TOKEN for SonarQube Cloud quality-gate polling; required when enable-sonar-quality-gate is true'
         required: false
 
 permissions:
@@ -770,10 +827,30 @@ jobs:
       # Phase 3 toggle point (ADR-0044 packet 14): change this warning-only job
       # to fail for size_band == 'oversize' when the Grid adopts the harder posture.
 
-  # Job 10: PR Summary and Coverage Gate
+  # Job 10: SonarQube Cloud Quality Gate (Optional, ADR-0011 D11)
+  sonar-quality-gate:
+    name: SonarQube Cloud Quality Gate
+    if: ${{ inputs.enable-sonar-quality-gate && github.event_name == 'pull_request' }}
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-sonarcloud-quality-gate.yml@main
+    with:
+      sonar-organization: ${{ inputs.sonar-organization }}
+      sonar-project-key: ${{ inputs.sonar-project-key }}
+      mode: ${{ inputs.sonar-quality-gate-mode }}
+      max-new-violations: ${{ inputs.sonar-max-new-violations }}
+      max-new-bugs: ${{ inputs.sonar-max-new-bugs }}
+      max-new-vulnerabilities: ${{ inputs.sonar-max-new-vulnerabilities }}
+      max-new-code-smells: ${{ inputs.sonar-max-new-code-smells }}
+      max-new-security-hotspots: ${{ inputs.sonar-max-new-security-hotspots }}
+      runs-on: ${{ inputs.runs-on }}
+    secrets:
+      sonar-token: ${{ secrets.sonar-token }}
+    permissions:
+      contents: read
+
+  # Job 11: PR Summary and Coverage Gate
   pr-summary:
     name: PR Summary and Coverage Gate
-    needs: [build-and-test, static-analysis, secret-scan, dependency-scan, codeql, authorship-check, pr-metadata-check, nuget-version-consistency-check, pr-size-check]
+    needs: [build-and-test, static-analysis, secret-scan, dependency-scan, codeql, authorship-check, pr-metadata-check, nuget-version-consistency-check, pr-size-check, sonar-quality-gate]
     if: ${{ always() }}
     runs-on: ${{ inputs.runs-on }}
     permissions:
@@ -1124,6 +1201,7 @@ jobs:
           DEPS_RESULT="${{ needs.dependency-scan.result }}"
           CODEQL_RESULT="${{ needs.codeql.result }}"
           NUGET_VERSION_RESULT="${{ needs.nuget-version-consistency-check.result }}"
+          SONAR_GATE_RESULT="${{ needs.sonar-quality-gate.result }}"
 
           # Collect warnings - use empty defaults for skipped jobs
           BUILD_WARNINGS="${{ needs.build-and-test.outputs.has-warnings }}"
@@ -1131,20 +1209,22 @@ jobs:
           SECRETS_WARNINGS="${{ needs.secret-scan.outputs.has-warnings || 'false' }}"
           DEPS_WARNINGS="${{ needs.dependency-scan.outputs.has-warnings || 'false' }}"
           CODEQL_WARNINGS="${{ needs.codeql.outputs.has-warnings || 'false' }}"
+          SONAR_GATE_WARNINGS="${{ needs.sonar-quality-gate.outputs.gate_failed || 'false' }}"
 
           BUILD_WARNING_MSG="${{ needs.build-and-test.outputs.warning-messages }}"
           ANALYSIS_WARNING_MSG="${{ needs.static-analysis.outputs.warning-messages }}"
           SECRETS_WARNING_MSG="${{ needs.secret-scan.outputs.warning-messages }}"
           DEPS_WARNING_MSG="${{ needs.dependency-scan.outputs.warning-messages }}"
           CODEQL_WARNING_MSG="${{ needs.codeql.outputs.warning-messages }}"
+          SONAR_GATE_WARNING_MSG="${{ needs.sonar-quality-gate.outputs.summary_line }}"
 
           COVERAGE_GATE_FAILED="${{ steps.coverage-gate.outputs.gate_failed || 'false' }}"
 
           # Determine status - don't fail on skipped jobs
-          if [[ "$BUILD_RESULT" == "failure" || "$ANALYSIS_RESULT" == "failure" || "$SECRETS_RESULT" == "failure" || "$DEPS_RESULT" == "failure" || "$CODEQL_RESULT" == "failure" || "$NUGET_VERSION_RESULT" == "failure" || "$COVERAGE_GATE_FAILED" == "true" ]]; then
+          if [[ "$BUILD_RESULT" == "failure" || "$ANALYSIS_RESULT" == "failure" || "$SECRETS_RESULT" == "failure" || "$DEPS_RESULT" == "failure" || "$CODEQL_RESULT" == "failure" || "$NUGET_VERSION_RESULT" == "failure" || "$SONAR_GATE_RESULT" == "failure" || "$COVERAGE_GATE_FAILED" == "true" ]]; then
             echo "icon=:x:" >> $GITHUB_OUTPUT
             echo "status=Failed" >> $GITHUB_OUTPUT
-          elif [[ "$BUILD_WARNINGS" == "true" || "$ANALYSIS_WARNINGS" == "true" || "$SECRETS_WARNINGS" == "true" || "$DEPS_WARNINGS" == "true" || "$CODEQL_WARNINGS" == "true" ]]; then
+          elif [[ "$BUILD_WARNINGS" == "true" || "$ANALYSIS_WARNINGS" == "true" || "$SECRETS_WARNINGS" == "true" || "$DEPS_WARNINGS" == "true" || "$CODEQL_WARNINGS" == "true" || "$SONAR_GATE_WARNINGS" == "true" ]]; then
             echo "icon=:warning:" >> $GITHUB_OUTPUT
             echo "status=Passed with Warnings" >> $GITHUB_OUTPUT
           else
@@ -1173,6 +1253,10 @@ jobs:
           if [[ "$CODEQL_WARNINGS" == "true" && -n "$CODEQL_WARNING_MSG" ]]; then
             WARNINGS_SECTION="${WARNINGS_SECTION}
           - :warning: **CodeQL:** $CODEQL_WARNING_MSG"
+          fi
+          if [[ "$SONAR_GATE_WARNINGS" == "true" && -n "$SONAR_GATE_WARNING_MSG" ]]; then
+            WARNINGS_SECTION="${WARNINGS_SECTION}
+          - :warning: **SonarQube Cloud Quality Gate:** $SONAR_GATE_WARNING_MSG"
           fi
 
           # Save to output
@@ -1205,6 +1289,10 @@ jobs:
           JOB_PR_METADATA_RESULT: ${{ needs.pr-metadata-check.result }}
           JOB_NUGET_VERSION_RESULT: ${{ needs.nuget-version-consistency-check.result }}
           JOB_PR_SIZE_RESULT: ${{ needs.pr-size-check.result }}
+          JOB_SONAR_GATE_RESULT: ${{ needs.sonar-quality-gate.result }}
+          SONAR_GATE_VERDICT: ${{ needs.sonar-quality-gate.outputs.verdict }}
+          SONAR_GATE_BREACHED_COUNT: ${{ needs.sonar-quality-gate.outputs.breached_count }}
+          SONAR_GATE_BREACH_SUMMARY: ${{ needs.sonar-quality-gate.outputs.breach_summary }}
           WARNINGS_BLOCK: ${{ steps.status.outputs.warnings }}
           COVERAGE_GATE_DETAIL: ${{ steps.coverage-gate.outputs.detail }}
           BUILD_CONFIGURATION: ${{ inputs.configuration }}
@@ -1263,6 +1351,14 @@ jobs:
             echo "- **NuGet Version Consistency:** $JOB_NUGET_VERSION_RESULT"
             echo "- **PR Size Check:** $JOB_PR_SIZE_RESULT"
           } >> message.md
+
+          if [ "$JOB_SONAR_GATE_RESULT" != "skipped" ]; then
+            if [ -n "$SONAR_GATE_BREACH_SUMMARY" ]; then
+              echo "- **SonarQube Cloud Quality Gate:** $JOB_SONAR_GATE_RESULT - ${SONAR_GATE_VERDICT:-breaches found} (${SONAR_GATE_BREACHED_COUNT:-0} metric breach(es): $SONAR_GATE_BREACH_SUMMARY)" >> message.md
+            else
+              echo "- **SonarQube Cloud Quality Gate:** $JOB_SONAR_GATE_RESULT${SONAR_GATE_VERDICT:+ - $SONAR_GATE_VERDICT}" >> message.md
+            fi
+          fi
 
           if [ -n "$COVERAGE_GATE_DETAIL" ]; then
             {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `job-sonarcloud-quality-gate.yml` and `pr-core.yml`: added an opt-in ADR-0011 D11 SonarQube Cloud quality gate that polls PR new-code metrics (`new_violations`, `new_bugs`, `new_vulnerabilities`, `new_code_smells`, and `new_security_hotspots`) and compares them against configurable thresholds. The default posture is no behavior change (`enable-sonar-quality-gate: false`) and soft launch when enabled (`sonar-quality-gate-mode: warn`); repos can flip to `enforce` after observing real PRs. Breaches surface in the check annotations and PR summary so SonarQube Cloud's free-tier default gate no longer silently passes PRs that introduce new issues or hotspots.
+
 - `release.yml`: added centralized GitHub Release creation with generated HoneyDrunk release notes. Consumers now pass release metadata (`release-product-name`, `release-product-description`, `release-nuget-packages`, `release-docs-url`) into the reusable release workflow instead of carrying repo-local checkout/generate-notes/`softprops/action-gh-release` jobs.
 
 - `job-solution-preflight.yml`: new reusable scaffold preflight job for repos whose solution or project path may not exist yet. Consumer repos can gate PR/nightly/release callers without duplicating local `actions/checkout` + file-exists shell snippets.

--- a/docs/consumer-usage.md
+++ b/docs/consumer-usage.md
@@ -29,6 +29,7 @@ The canonical permissions baselines below are minimum sets. Granting more than r
 | `nightly-deps.yml` | `contents: write`, `pull-requests: write`, `issues: write` |
 | `nightly-accessibility.yml` | `contents: read`, `issues: write` |
 | `weekly-governance.yml` | `contents: read`, `issues: write` |
+| `job-sonarcloud-quality-gate.yml` | `contents: read` |
 
 For workflows not explicitly listed in ADR-0012 D5, the baseline is derived from the callee workflow's declared top-level and job-level `permissions:` blocks in `.github/workflows/<callee>.yml`.
 
@@ -36,6 +37,7 @@ For workflows not explicitly listed in ADR-0012 D5, the baseline is derived from
 
 - [Caller permissions — the load-bearing rule](#caller-permissions--the-load-bearing-rule)
 - [PR Core Workflow](#pr-core-workflow)
+- [SonarQube Cloud Quality Gate](#sonarqube-cloud-quality-gate)
 - [PR SDK Workflow](#pr-sdk-workflow)
 - [Grid Review Request Workflow](#grid-review-request-workflow)
 - [Release Workflow](#release-workflow)
@@ -138,6 +140,59 @@ with:
   absolute-coverage-floor: 70
 ```
 
+### SonarQube Cloud Quality Gate
+
+`pr-core.yml` can optionally poll SonarQube Cloud PR new-code metrics after `job-sonarcloud.yml` has uploaded analysis data. This exists because the free SonarQube Cloud "Sonar way" gate cannot be customized to fail on every new issue, so HoneyDrunk enforces ADR-0011 D11 thresholds in Actions while using SonarQube Cloud as the data source.
+
+Default posture is off and warn-only:
+
+- `enable-sonar-quality-gate: false` means existing consumers do not change behavior.
+- `sonar-quality-gate-mode: warn` reports breaches in the check and PR summary without failing the PR.
+- `sonar-quality-gate-mode: enforce` fails the PR when any configured threshold is exceeded.
+- Missing PR measures are reported as a warning and do not hard-fail, matching fork PRs or caller workflows that skipped Sonar analysis. SonarQube Cloud authorization and configuration errors fail because the gate could not evaluate the PR.
+
+Start with a per-repo opt-in like:
+
+```yaml
+with:
+  enable-sonar-quality-gate: true
+  sonar-quality-gate-mode: warn
+  sonar-organization: 'honeydrunkstudios'
+  sonar-project-key: 'honeydrunkstudios_HoneyDrunk.Vault'
+secrets:
+  github-token: ${{ secrets.GITHUB_TOKEN }}
+  sonar-token: ${{ secrets.SONAR_TOKEN }}
+```
+
+Sequencing matters. Current HoneyDrunk consumer workflows usually run the `sonarcloud` job after `pr-core`, so immediate blocking enforcement should call the standalone gate after `sonarcloud`:
+
+```yaml
+  sonar-quality-gate:
+    name: SonarQube Cloud Quality Gate
+    if: github.event_name == 'pull_request' && needs.sonarcloud.result == 'success'
+    needs: sonarcloud
+    permissions:
+      contents: read
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-sonarcloud-quality-gate.yml@main
+    with:
+      sonar-organization: 'honeydrunkstudios'
+      sonar-project-key: 'honeydrunkstudios_HoneyDrunk.Vault'
+      mode: enforce
+    secrets:
+      sonar-token: ${{ secrets.SONAR_TOKEN }}
+```
+
+Threshold inputs default to zero, meaning no new issues or hotspots are allowed:
+
+```yaml
+with:
+  sonar-max-new-violations: 0
+  sonar-max-new-bugs: 0
+  sonar-max-new-vulnerabilities: 0
+  sonar-max-new-code-smells: 0
+  sonar-max-new-security-hotspots: 0
+```
+
 ### Full Example with Options
 
 ```yaml
@@ -178,6 +233,7 @@ jobs:
       enable-codeql: true
       codeql-queries: 'security-and-quality'
       codeql-fail-on-severity: 'note'   # any finding blocks; set 'warning' or 'error' to loosen
+      enable-sonar-quality-gate: false
       enable-accessibility-check: false
       patch-coverage-threshold: 75
       absolute-coverage-floor: 70
@@ -185,6 +241,8 @@ jobs:
       actions-ref: 'main'
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
+      # Required only when enable-sonar-quality-gate is true.
+      # sonar-token: ${{ secrets.SONAR_TOKEN }}
 
   coverage-baseline-ratchet:
     if: github.event_name == 'push'


### PR DESCRIPTION
## Summary
- Adds `job-sonarcloud-quality-gate.yml`, a reusable SonarQube Cloud new-code metrics gate for ADR-0011 D11.
- Extends `pr-core.yml` with opt-in Sonar gate inputs, `SONAR_TOKEN` wiring, and PR summary reporting.
- Documents consumer opt-in, direct post-`sonarcloud` sequencing, thresholds, permissions, and changelog entry.

Authorship: agent-codex

Packet: https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/ea40665cb227c19595c4cb7470299497515fe7e6/generated/issue-packets/active/adr-0011-code-review-pipeline/08-actions-sonarcloud-quality-gate-enforcement.md
Out-of-band reason: N/A

## Verification
- `actionlint -color -shellcheck=`
- YAML parse for `pr-core.yml` and `job-sonarcloud-quality-gate.yml`
- `git diff --cached --check`
- banned CI secret-pattern check
- `tests/grid-health-aggregator-smoke.sh` via Git Bash

Size justification: Packet 08 adds a full reusable workflow plus `pr-core.yml` opt-in wiring and consumer documentation. Keeping them in one PR makes the workflow contract, caller surface, and docs reviewable together without splitting dependent CI behavior across PRs.