### PR TITLE
Add ADR-0086 review labels

### DIFF
--- a/.github/config/labels.json
+++ b/.github/config/labels.json
@@ -19,6 +19,126 @@
       "name": "skip-review",
       "color": "cfd3d7",
       "description": "Manual ADR-0044 escape hatch; Grid Review Runner skips PRs carrying this label."
+    },
+    {
+      "name": "needs-agent-review",
+      "color": "1d76db",
+      "description": "PR is in the Grid Review Runner queue; the pull-based local worker will pick it up on its next tick."
+    },
+    {
+      "name": "agent-review-in-progress",
+      "color": "e3b341",
+      "description": "Local worker has claimed the PR and is running the Grid review."
+    },
+    {
+      "name": "agent-reviewed",
+      "color": "0e8a16",
+      "description": "Local worker posted a clean Grid review verdict."
+    },
+    {
+      "name": "changes-requested-by-agent",
+      "color": "b60205",
+      "description": "Local worker posted a Grid review verdict with blocking or request-changes findings."
+    },
+    {
+      "name": "meta",
+      "color": "6f42c1",
+      "description": "Architecture, governance, catalog, or process work."
+    },
+    {
+      "name": "docs",
+      "color": "0075ca",
+      "description": "Documentation-only or documentation-primary changes."
+    },
+    {
+      "name": "ci",
+      "color": "0052cc",
+      "description": "GitHub Actions, build, release, or workflow changes."
+    },
+    {
+      "name": "bug",
+      "color": "d73a4a",
+      "description": "Defect fix."
+    },
+    {
+      "name": "enhancement",
+      "color": "a2eeef",
+      "description": "Product or capability improvement."
+    },
+    {
+      "name": "dependencies",
+      "color": "0366d6",
+      "description": "Package, tool, SDK, or dependency update."
+    },
+    {
+      "name": "chore",
+      "color": "fef2c0",
+      "description": "Maintenance work that is not a feature, bug, or refactor."
+    },
+    {
+      "name": "security",
+      "color": "ee0701",
+      "description": "Security-sensitive code, configuration, or process changes."
+    },
+    {
+      "name": "breaking-change",
+      "color": "cc0000",
+      "description": "Public API, schema, workflow contract, or behavior change requiring consumer action."
+    },
+    {
+      "name": "refactor",
+      "color": "c5def5",
+      "description": "Behavior-preserving structural change."
+    },
+    {
+      "name": "test",
+      "color": "bfdadc",
+      "description": "Test-only or test-infrastructure change."
+    },
+    {
+      "name": "infra",
+      "color": "4c1d95",
+      "description": "GitHub Apps, Vault, Azure, local worker, Task Scheduler, or deployment plumbing."
+    },
+    {
+      "name": "automation",
+      "color": "2ea44f",
+      "description": "Agent, bot, scheduled-runner, or automated workflow behavior."
+    },
+    {
+      "name": "human-only",
+      "color": "f9d0c4",
+      "description": "Work requiring manual portal, account, or operator action."
+    },
+    {
+      "name": "blocked",
+      "color": "e11d21",
+      "description": "Work cannot proceed until an external or manual prerequisite clears."
+    },
+    {
+      "name": "superseded",
+      "color": "bfd4f2",
+      "description": "Issue, packet, or PR replaced by newer scoped work."
+    },
+    {
+      "name": "new-node",
+      "color": "c2e0c6",
+      "description": "New Grid Node or repository standup work."
+    },
+    {
+      "name": "catalog",
+      "color": "d4c5f9",
+      "description": "Architecture catalog or index changes."
+    },
+    {
+      "name": "contracts",
+      "color": "7057ff",
+      "description": "Public abstractions, API contracts, or compatibility surface."
+    },
+    {
+      "name": "scaffolding",
+      "color": "ffd33d",
+      "description": "Initial repository, Node, or project setup."
     }
   ]
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `.github/config/labels.json`: added ADR-0086 worker-state labels (`needs-agent-review`, `agent-review-in-progress`, `agent-reviewed`, `changes-requested-by-agent`) plus the managed PR-label vocabulary used by the upcoming label-normalizing review enqueue workflow.
+
 - `job-sonarcloud-quality-gate.yml` and `pr-core.yml`: added an opt-in ADR-0011 D11 SonarQube Cloud quality gate that polls PR new-code metrics (`new_violations`, `new_bugs`, `new_vulnerabilities`, `new_code_smells`, and `new_security_hotspots`) and compares them against configurable thresholds. The default posture is no behavior change (`enable-sonar-quality-gate: false`) and soft launch when enabled (`sonar-quality-gate-mode: warn`); repos can flip to `enforce` after observing real PRs. Breaches surface in the check annotations and PR summary so SonarQube Cloud's free-tier default gate no longer silently passes PRs that introduce new issues or hotspots.
 
 - `release.yml`: added centralized GitHub Release creation with generated HoneyDrunk release notes. Consumers now pass release metadata (`release-product-name`, `release-product-description`, `release-nuget-packages`, `release-docs-url`) into the reusable release workflow instead of carrying repo-local checkout/generate-notes/`softprops/action-gh-release` jobs.


### PR DESCRIPTION
## Summary
- Add ADR-0086 worker-state labels to labels-as-code
- Add the managed PR-label vocabulary used by the upcoming label-normalizing enqueue workflow
- Record the labels-as-code expansion in the Actions changelog

## Verification
- `git diff --check`
- Parsed `.github/config/labels.json` with PowerShell `ConvertFrom-Json`
- Verified no duplicate label names or colors

Closes #162