### PR TITLE
Refresh labels fan-out targets

### DIFF
--- a/.github/workflows/seed-labels-fanout.yml
+++ b/.github/workflows/seed-labels-fanout.yml
@@ -27,7 +27,7 @@ on:
         required: false
         type: string
         default: >-
-          HoneyDrunk.Kernel,HoneyDrunk.Transport,HoneyDrunk.Vault,HoneyDrunk.Auth,HoneyDrunk.Web.Rest,HoneyDrunk.Data,HoneyDrunk.Notify,HoneyDrunk.Communications,HoneyDrunk.Pulse,HoneyDrunk.Actions,HoneyDrunk.Architecture,HoneyDrunkStudios
+          HoneyDrunk.Kernel,HoneyDrunk.Transport,HoneyDrunk.Vault,HoneyDrunk.Vault.Rotation,HoneyDrunk.Auth,HoneyDrunk.Web.Rest,HoneyDrunk.Data,HoneyDrunk.Notify,HoneyDrunk.Communications,HoneyDrunk.Pulse,HoneyDrunk.Audit,HoneyDrunk.Observe,HoneyDrunk.AI,HoneyDrunk.Operator,HoneyDrunk.Flow,HoneyDrunk.Memory,HoneyDrunk.Knowledge,HoneyDrunk.Capabilities,HoneyDrunk.Agents,HoneyDrunk.Lore,HoneyDrunk.Standards,HoneyDrunk.Actions,HoneyDrunk.Architecture,HoneyDrunkStudios,.github,TheHive
 
 permissions:
   contents: read

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `seed-labels-fanout.yml`: refreshed the default Grid fan-out target list so the labels-as-code seed reaches newer repos, including Audit, Observe, AI, Operator, Flow, Memory, Knowledge, Capabilities, Agents, Lore, Standards, `.github`, and TheHive.
+
 - `docs/consumer-usage.md`: documented the standard caller split. Consumer workflows own triggers, version/environment resolution, and repo-specific metadata only; reusable workflow mechanics stay in `HoneyDrunk.Actions`.
 
 - `actions-ci.yml`: chose D4 Outcome B for `docker://` refs and migrated actionlint to direct install-and-invoke.


### PR DESCRIPTION
## Summary
- expand the labels-as-code fan-out default target list to include newer active Grid repos
- document the fan-out target refresh in the changelog

## Validation
- `python -m json.tool .github/config/labels.json`
- verified every default target repo exists with `gh repo view`
- `git diff --check`

Note: `actionlint` was not installed locally, so workflow linting is left to CI.