### PR TITLE
Allow review request workflow to write PR state

### DIFF
--- a/.github/workflows/job-review-request.yml
+++ b/.github/workflows/job-review-request.yml
@@ -85,7 +85,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 jobs:

--- a/.github/workflows/job-review-request.yml
+++ b/.github/workflows/job-review-request.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Checkout repository
         if: ${{ steps.event.outputs.skip != 'true' }}
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary
- grant the ADR-0086 review-request reusable workflow `pull-requests: write`
- pin `actions/checkout` in the reusable workflow to the current v5 commit SHA
- keep contents read and issues write unchanged

## Why
Architecture callers now request `pull-requests: write`, but the reusable workflow still capped its own token at `pull-requests: read`, causing `Resource not accessible by integration` when adding the local-worker queue label.

## Verification
- Actions Repo CI / Lint workflows and secret policy: passing
- Grid Review Request: passing after applying the canonical `skip-review` label to this self-fixing PR; without that escape hatch the base-branch `@main` workflow tries the broken label write before this PR can update it.
- CodeRabbit checkout-pin comment addressed by replacing `actions/checkout@v5` with commit `93cb6efe18208431cddfb8368fd83d5badbf9bfd`.

Authorship: agent-codex
Packet: generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/05-actions-rewrite-job-review-request-as-label-and-comment.md
