### PR TITLE
Add ADR-0086 PR label classification

### DIFF
--- a/.github/workflows/job-review-request.yml
+++ b/.github/workflows/job-review-request.yml
@@ -7,6 +7,7 @@
 # Responsibilities:
 #   - Decide whether a pull request should request Grid review
 #   - Build the versioned review-request payload
+#   - Apply high-confidence PR classification labels that already exist
 #   - Normalize worker-state labels for the PR/head SHA
 #   - Upsert the structured queue comment consumed by the local worker
 #
@@ -75,6 +76,11 @@ on:
         required: false
         type: string
         default: 'honeydrunk-grid-review-queue:v1'
+      apply-classification-labels:
+        description: 'Apply inferred non-worker PR labels when those labels already exist on the target repository'
+        required: false
+        type: boolean
+        default: true
     secrets:
       openclaw-webhook-secret:
         description: 'Deprecated ADR-0044 secret retained for compatibility; local-worker queueing ignores it'
@@ -289,6 +295,118 @@ jobs:
               output.write(f"deletions={deletions}\n")
           PY
 
+      - name: Apply PR classification labels
+        if: ${{ inputs.apply-classification-labels && steps.event.outputs.skip != 'true' && steps.gate.outputs.skip != 'true' }}
+        id: classification
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.github-token }}
+          EVENT_PATH: ${{ github.event_path }}
+          QUEUE_LABEL: ${{ inputs.queue-label }}
+          IN_PROGRESS_LABEL: ${{ inputs.in-progress-label }}
+          REVIEWED_LABEL: ${{ inputs.reviewed-label }}
+          CHANGES_REQUESTED_LABEL: ${{ inputs.changes-requested-label }}
+        run: |
+          set -euo pipefail
+
+          repo='${{ github.repository }}'
+          pr_number='${{ github.event.pull_request.number }}'
+
+          gh api "repos/${repo}/labels?per_page=100" --paginate --slurp > repo-labels.json
+
+          python3 - <<'PY' > inferred-labels.txt
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          event = json.loads(Path(os.environ['EVENT_PATH']).read_text(encoding='utf-8'))
+          pages = json.loads(Path('changed-files.json').read_text(encoding='utf-8'))
+          files = [item for page in pages for item in page]
+          label_pages = json.loads(Path('repo-labels.json').read_text(encoding='utf-8'))
+          existing = {item['name'].lower(): item['name'] for page in label_pages for item in page}
+
+          worker_labels = {
+              os.environ['QUEUE_LABEL'].lower(),
+              os.environ['IN_PROGRESS_LABEL'].lower(),
+              os.environ['REVIEWED_LABEL'].lower(),
+              os.environ['CHANGES_REQUESTED_LABEL'].lower(),
+          }
+
+          pr = event['pull_request']
+          title = pr.get('title') or ''
+          body = pr.get('body') or ''
+          paths = [item['filename'] for item in files]
+          text = '\n'.join([title, body, *paths]).lower()
+          candidates = []
+
+          def add(label):
+              key = label.lower()
+              if key in worker_labels:
+                  return
+              if key in existing and existing[key] not in candidates:
+                  candidates.append(existing[key])
+
+          adr_numbers = sorted(set(re.findall(r'adr[-_/ ]?0*(\d{1,4})', text)))
+          for number in adr_numbers:
+              add(f"adr-{int(number):04d}")
+
+          markdown_paths = [path for path in paths if path.lower().endswith('.md')]
+          if markdown_paths and len(markdown_paths) == len(paths):
+              add('docs')
+          if any(path.startswith(('adrs/', 'constitution/', 'catalogs/', 'initiatives/', 'repos/')) for path in paths):
+              add('architecture')
+              add('governance')
+          if any(path.startswith('constitution/') for path in paths):
+              add('constitution')
+          if any(path.startswith('catalogs/') for path in paths):
+              add('catalog')
+          if any(path.startswith('infrastructure/') for path in paths) or ' infrastructure' in f' {text}':
+              add('infrastructure')
+          if any(path.startswith('.github/workflows/') or path.endswith(('.yml', '.yaml')) for path in paths):
+              add('ci')
+
+          security_terms = ('secret', 'credential', 'token', 'key vault', 'pat', 'api key', 'rotation', 'sensitive')
+          if any(term in text for term in security_terms):
+              add('security')
+              add('secrets')
+
+          if 'bug' in text or 'fix' in title.lower():
+              add('bug')
+          elif any(word in text for word in ('add ', 'create ', 'introduce ', 'standup', 'stand up', 'enable ', 'accept adr')):
+              add('enhancement')
+
+          node_terms = {
+              'actions': ('honeydrunk.actions', '/actions', 'actions/'),
+              'agents': ('honeydrunk.agents',),
+              'ai': ('honeydrunk.ai',),
+              'audit': ('honeydrunk.audit',),
+              'cache': ('honeydrunk.cache', 'redis'),
+              'core': ('honeydrunk.core',),
+              'files': ('honeydrunk.files',),
+              'identity': ('honeydrunk.identity', 'entra'),
+              'web-ui': ('honeydrunk.web.ui', 'web.ui'),
+          }
+          for label, needles in node_terms.items():
+              if any(needle in text for needle in needles):
+                  add(label)
+
+          for label in candidates:
+              print(label)
+          PY
+
+          if [ -s inferred-labels.txt ]; then
+            while IFS= read -r label; do
+              gh issue edit "$pr_number" --repo "$repo" --add-label "$label"
+            done < inferred-labels.txt
+            labels="$(paste -sd ',' inferred-labels.txt)"
+            echo "labels=${labels}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Applied PR classification labels: ${labels}"
+          else
+            echo "labels=" >> "$GITHUB_OUTPUT"
+            echo "::notice::No existing high-confidence PR classification labels matched."
+          fi
+
       - name: Normalize local-worker queue labels
         if: ${{ steps.event.outputs.skip != 'true' && steps.gate.outputs.skip != 'true' }}
         shell: bash
@@ -410,5 +528,6 @@ jobs:
             echo "- Additions/deletions: +${{ steps.payload.outputs.additions }} / -${{ steps.payload.outputs.deletions }}"
             echo "- Queue label: ${{ inputs.queue-label }}"
             echo "- Queue marker: ${{ inputs.queue-comment-marker }}"
+            echo "- Classification labels: ${{ steps.classification.outputs.labels }}"
             echo "- Advisory only: true"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/job-review-request.yml
+++ b/.github/workflows/job-review-request.yml
@@ -355,6 +355,7 @@ jobs:
           if markdown_paths and len(markdown_paths) == len(paths):
               add('docs')
           if any(path.startswith(('adrs/', 'constitution/', 'catalogs/', 'initiatives/', 'repos/')) for path in paths):
+              add('meta')
               add('architecture')
               add('governance')
           if any(path.startswith('constitution/') for path in paths):
@@ -362,7 +363,7 @@ jobs:
           if any(path.startswith('catalogs/') for path in paths):
               add('catalog')
           if any(path.startswith('infrastructure/') for path in paths) or ' infrastructure' in f' {text}':
-              add('infrastructure')
+              add('infra')
           if any(path.startswith('.github/workflows/') or path.endswith(('.yml', '.yaml')) for path in paths):
               add('ci')
 
@@ -371,7 +372,7 @@ jobs:
               add('security')
               add('secrets')
 
-          if 'bug' in text or 'fix' in title.lower():
+          if re.search(r'\bbugs?\b', text) or re.search(r'\bfix(?:e[sd])?\b', title.lower()):
               add('bug')
           elif any(word in text for word in ('add ', 'create ', 'introduce ', 'standup', 'stand up', 'enable ', 'accept adr')):
               add('enhancement')
@@ -397,7 +398,9 @@ jobs:
 
           if [ -s inferred-labels.txt ]; then
             while IFS= read -r label; do
-              gh issue edit "$pr_number" --repo "$repo" --add-label "$label"
+              if ! gh issue edit "$pr_number" --repo "$repo" --add-label "$label"; then
+                echo "::warning::Could not apply optional classification label '${label}'. Continuing with Grid review queueing."
+              fi
             done < inferred-labels.txt
             labels="$(paste -sd ',' inferred-labels.txt)"
             echo "labels=${labels}" >> "$GITHUB_OUTPUT"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `job-review-request.yml`: added central high-confidence PR label classification before ADR-0086 queueing. The workflow now infers existing labels such as ADR number, docs, governance, architecture, security, secrets, CI, and known node labels from the PR title/body/files, while preserving the worker-state labels as queue mechanics only.
+
 - `.github/config/labels.json`: added ADR-0086 worker-state labels (`needs-agent-review`, `agent-review-in-progress`, `agent-reviewed`, `changes-requested-by-agent`) plus the managed PR-label vocabulary used by the upcoming label-normalizing review enqueue workflow.
 
 - `job-sonarcloud-quality-gate.yml` and `pr-core.yml`: added an opt-in ADR-0011 D11 SonarQube Cloud quality gate that polls PR new-code metrics (`new_violations`, `new_bugs`, `new_vulnerabilities`, `new_code_smells`, and `new_security_hotspots`) and compares them against configurable thresholds. The default posture is no behavior change (`enable-sonar-quality-gate: false`) and soft launch when enabled (`sonar-quality-gate-mode: warn`); repos can flip to `enforce` after observing real PRs. Breaches surface in the check annotations and PR summary so SonarQube Cloud's free-tier default gate no longer silently passes PRs that introduce new issues or hotspots.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `job-review-request.yml`: added central high-confidence PR label classification before ADR-0086 queueing. The workflow now infers existing labels such as ADR number, docs, governance, architecture, security, secrets, CI, and known node labels from the PR title/body/files, while preserving the worker-state labels as queue mechanics only.
+- `job-review-request.yml`: added central high-confidence PR label classification before ADR-0086 queueing. The workflow now infers existing labels such as ADR number, docs, meta, infra, security, secrets, CI, and known node labels from the PR title/body/files, while preserving the worker-state labels as queue mechanics only.
 
 - `.github/config/labels.json`: added ADR-0086 worker-state labels (`needs-agent-review`, `agent-review-in-progress`, `agent-reviewed`, `changes-requested-by-agent`) plus the managed PR-label vocabulary used by the upcoming label-normalizing review enqueue workflow.
 

--- a/docs/consumer-usage.md
+++ b/docs/consumer-usage.md
@@ -298,7 +298,7 @@ jobs:
 
 ## Grid Review Request Workflow
 
-**Purpose:** Advisory ADR-0086 trigger rail for the pull-based local-worker Grid Review Runner. This workflow does **not** run Codex, Claude, Anthropic, OpenAI, or any model API in GitHub Actions. It normalizes the worker-state labels and upserts a structured queue comment that the local worker polls.
+**Purpose:** Advisory ADR-0086 trigger rail for the pull-based local-worker Grid Review Runner. This workflow does **not** run Codex, Claude, Anthropic, OpenAI, or any model API in GitHub Actions. It applies high-confidence PR classification labels that already exist on the target repository, normalizes the worker-state labels, and upserts a structured queue comment that the local worker polls.
 
 **When to Use:** Repos that opt in to automatic Grid review by adding `.honeydrunk-review.yaml` with `enabled: true`. Start with `HoneyDrunk.Architecture` for the Phase 1 pilot.
 
@@ -348,7 +348,9 @@ The workflow emits the ADR-0086 `grid-review-request` payload into a machine-rea
 owner/repo#pr@headSha
 ```
 
-It adds `needs-agent-review`, removes stale worker-state completion/claim labels, and upserts a comment marked `honeydrunk-grid-review-queue:v1` containing `head_sha`, `queued_at`, `runner`, `risk_class`, and the workflow run metadata. The local worker claims the PR by replacing `needs-agent-review` with `agent-review-in-progress`, runs the subscribed local CLI review, and posts one advisory verdict for the recorded head SHA.
+It adds `needs-agent-review`, removes stale worker-state completion/claim labels, and upserts a comment marked `honeydrunk-grid-review-queue:v1` containing `head_sha`, `queued_at`, `runner`, `risk_class`, and the workflow run metadata. The workflow also infers existing non-worker labels from PR title/body/files, such as ADR number, docs, governance, architecture, security, secrets, and known node labels. The local worker claims the PR by replacing `needs-agent-review` with `agent-review-in-progress`, runs the subscribed local CLI review, and posts one advisory verdict for the recorded head SHA.
+
+Set `apply-classification-labels: false` only for a repo that wants the review queue without central PR label classification.
 
 The old OpenClaw webhook inputs are retained as no-op compatibility shims during the cutover, but new callers should not pass them.
 

--- a/docs/consumer-usage.md
+++ b/docs/consumer-usage.md
@@ -348,7 +348,7 @@ The workflow emits the ADR-0086 `grid-review-request` payload into a machine-rea
 owner/repo#pr@headSha
 ```
 
-It adds `needs-agent-review`, removes stale worker-state completion/claim labels, and upserts a comment marked `honeydrunk-grid-review-queue:v1` containing `head_sha`, `queued_at`, `runner`, `risk_class`, and the workflow run metadata. The workflow also infers existing non-worker labels from PR title/body/files, such as ADR number, docs, governance, architecture, security, secrets, and known node labels. The local worker claims the PR by replacing `needs-agent-review` with `agent-review-in-progress`, runs the subscribed local CLI review, and posts one advisory verdict for the recorded head SHA.
+It adds `needs-agent-review`, removes stale worker-state completion/claim labels, and upserts a comment marked `honeydrunk-grid-review-queue:v1` containing `head_sha`, `queued_at`, `runner`, `risk_class`, and the workflow run metadata. The workflow also infers existing non-worker labels from PR title/body/files, such as ADR number, docs, meta, infra, security, secrets, and known node labels. Optional classification failures warn and do not block queueing. The local worker claims the PR by replacing `needs-agent-review` with `agent-review-in-progress`, runs the subscribed local CLI review, and posts one advisory verdict for the recorded head SHA.
 
 Set `apply-classification-labels: false` only for a repo that wants the review queue without central PR label classification.
 


### PR DESCRIPTION
## Summary
- add central high-confidence PR label classification to the ADR-0086 review request workflow
- apply only labels that already exist on the target repo, keeping worker-state labels separate from PR taxonomy labels
- document the new classifier input and behavior for consumers

## Validation
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path(''.github/workflows/job-review-request.yml'').read_text(encoding=''utf-8'')); print(''yaml ok'')"`
- `git diff --check`

Authorship: agent-codex
Packet: ADR-0086 central PR label classification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic inference and application of high-confidence PR classification labels (ADR, docs-only, architecture/governance, security/secrets, CI, known node labels) based on PR title/body and changed files.
  * Optional toggle to enable or disable label classification (enabled by default); failures warn but do not block queueing.

* **Documentation**
  * Updated usage and changelog to describe the classification behavior and configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HoneyDrunkStudios/HoneyDrunk.Actions/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->