### PR TITLE
Persist ADR-0086 queue authorship metadata

### DIFF
--- a/.github/workflows/job-review-request.yml
+++ b/.github/workflows/job-review-request.yml
@@ -91,7 +91,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
   issues: write
 
 jobs:
@@ -222,9 +222,19 @@ jobs:
           config_path = Path(os.environ['REVIEW_CONFIG_PATH'])
           config_text = config_path.read_text(encoding='utf-8') if config_path.exists() else ''
 
+          allowed_authorship = {'human', 'agent-codex', 'agent-copilot', 'agent-claude-code', 'mixed'}
           authorship_match = re.search(r'(?im)^\s*Authorship\s*:\s*([^\r\n]+)', body)
-          authorship_class = authorship_match.group(1).strip() if authorship_match else 'unknown'
-          authorship_source = 'pr-body' if authorship_match else 'missing'
+          raw_authorship = authorship_match.group(1).strip().lower() if authorship_match else ''
+          if raw_authorship in allowed_authorship:
+              authorship_class = raw_authorship
+              authorship_source = 'pr-body'
+          elif authorship_match:
+              authorship_class = 'unknown'
+              authorship_source = 'invalid'
+              print('::warning::Invalid Authorship value; queue metadata will use unknown.')
+          else:
+              authorship_class = 'unknown'
+              authorship_source = 'missing'
 
           packet_url_match = re.search(r'https://github\.com/HoneyDrunkStudios/[^\s)]+/issues/\d+', body)
           packet_path_match = re.search(r'generated/issue-packets/[^\s)`]+\.md', body)
@@ -450,6 +460,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.github-token }}
           QUEUE_COMMENT_MARKER: ${{ inputs.queue-comment-marker }}
+          AUTHORSHIP_CLASS: ${{ steps.payload.outputs.authorship-class }}
         run: |
           set -euo pipefail
 
@@ -463,7 +474,7 @@ jobs:
           status: queued
           idempotency_key: ${{ steps.payload.outputs.idempotency-key }}
           head_sha: ${{ steps.payload.outputs.head-sha }}
-          authorship_class: ${{ steps.payload.outputs.authorship-class }}
+          authorship_class: ${AUTHORSHIP_CLASS}
           queued_at: ${queued_at}
           runner: ${{ steps.gate.outputs.runner }}
           risk_class: ${{ steps.gate.outputs.risk-class }}

--- a/.github/workflows/job-review-request.yml
+++ b/.github/workflows/job-review-request.yml
@@ -290,6 +290,7 @@ jobs:
           with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as output:
               output.write(f"idempotency-key={idempotency_key}\n")
               output.write(f"head-sha={head_sha}\n")
+              output.write(f"authorship-class={authorship_class}\n")
               output.write(f"changed-files={len(files)}\n")
               output.write(f"additions={additions}\n")
               output.write(f"deletions={deletions}\n")
@@ -462,6 +463,7 @@ jobs:
           status: queued
           idempotency_key: ${{ steps.payload.outputs.idempotency-key }}
           head_sha: ${{ steps.payload.outputs.head-sha }}
+          authorship_class: ${{ steps.payload.outputs.authorship-class }}
           queued_at: ${queued_at}
           runner: ${{ steps.gate.outputs.runner }}
           risk_class: ${{ steps.gate.outputs.risk-class }}


### PR DESCRIPTION
Authorship: agent-codex
Packet: HoneyDrunkStudios/HoneyDrunk.Architecture:generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/03-architecture-author-pull-worker.md

## Summary

- Persist queue-time PR authorship into the local-worker queue comment.
- Keep the runner's trust boundary on immutable queued metadata instead of later PR body edits.

## Validation

- Reviewed workflow diff for queue output/comment interpolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Review-request workflow now validates the PR authorship field and classifies it as valid, invalid, or missing.
  * Emits a warning when authorship is present but not allowed.
  * Exposes the computed authorship classification as an output.
  * Inserts the authorship classification into queued review comments.
  * Adjusted workflow permissions for review requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HoneyDrunkStudios/HoneyDrunk.Actions/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->