### PR TITLE
Fix credential drift token and grid review queue labels

### DIFF
--- a/.github/workflows/external-credentials-check.yml
+++ b/.github/workflows/external-credentials-check.yml
@@ -18,9 +18,13 @@
 #   - Discord escalation (ADR-0084 packet 10) is NOT shipped here; it edits this
 #     workflow later to add notify-discord call sites. Until then the only
 #     escalation surface is the gh-issue comment path.
-#   - Reuses GH_ISSUE_TOKEN (cost discipline, ADR-0083 D1). Because this workflow
-#     depends on that token, a silent GH_ISSUE_TOKEN expiry stops the watcher —
-#     the run-summary heartbeat + grid-health watch entry are the mitigation.
+#   - Authenticates with CREDENTIALS_CHECK_TOKEN, a dedicated fine-grained PAT
+#     scoped to HoneyDrunk.Architecture (Issues/Contents/Pull-requests RW). Because
+#     this workflow IS the credential-drift watcher, it cannot nag about its own
+#     token's expiry — a silent CREDENTIALS_CHECK_TOKEN lapse stops the watcher, so
+#     the run-summary heartbeat + grid-health watch entry are the mitigation, and the
+#     token's own inventory row flags "rotate proactively." (Replaces the never-
+#     provisioned GH_ISSUE_TOKEN the seed assumed; see ADR-0083 reconciliation.)
 # ==============================================================================
 
 name: External Credentials Drift Check
@@ -34,7 +38,7 @@ on:
 
 permissions:
   contents: read   # checkout the Actions repo (scripts). Every cross-repo issue/PR
-                   # operation uses GH_ISSUE_TOKEN, not this workflow's GITHUB_TOKEN,
+                   # operation uses CREDENTIALS_CHECK_TOKEN, not this workflow's GITHUB_TOKEN,
                    # so no issues:write is required on this repo's token.
 
 # Serialize runs: a scheduled tick and a manual run must not race between the
@@ -48,12 +52,12 @@ jobs:
   check-credentials:
     runs-on: ubuntu-latest
     steps:
-      - name: Verify GH_ISSUE_TOKEN is present
+      - name: Verify CREDENTIALS_CHECK_TOKEN is present
         env:
-          GH_ISSUE_TOKEN: ${{ secrets.GH_ISSUE_TOKEN }}
+          CREDENTIALS_CHECK_TOKEN: ${{ secrets.CREDENTIALS_CHECK_TOKEN }}
         run: |
-          if [ -z "$GH_ISSUE_TOKEN" ]; then
-            echo "::error::GH_ISSUE_TOKEN is not set. This workflow needs it to read the inventory in HoneyDrunk.Architecture and manage rotation issues. Bind the secret to this repo (or repoint the workflow at a valid token)." >&2
+          if [ -z "$CREDENTIALS_CHECK_TOKEN" ]; then
+            echo "::error::CREDENTIALS_CHECK_TOKEN is not set. This workflow needs it to read the inventory in HoneyDrunk.Architecture and manage rotation issues. Bind the secret to this repo (or repoint the workflow at a valid token)." >&2
             exit 1
           fi
 
@@ -61,7 +65,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Architecture
-          token: ${{ secrets.GH_ISSUE_TOKEN }}
+          token: ${{ secrets.CREDENTIALS_CHECK_TOKEN }}
           # persist-credentials stays at the default (true) ON PURPOSE: the T+0
           # path pushes an incident branch from this checkout via git, which needs
           # the token persisted in the local git config. The Actions checkout below
@@ -92,21 +96,21 @@ jobs:
 
       - name: Apply T-30 escalations (urgent label + comment)
         env:
-          GH_TOKEN: ${{ secrets.GH_ISSUE_TOKEN }}
+          GH_TOKEN: ${{ secrets.CREDENTIALS_CHECK_TOKEN }}
         run: |
           python3 actions/.github/scripts/inventory-escalate.py \
             --tier urgent_T30 --escalations escalations.json
 
       - name: Apply T-7 escalations (imminent label + comment)
         env:
-          GH_TOKEN: ${{ secrets.GH_ISSUE_TOKEN }}
+          GH_TOKEN: ${{ secrets.CREDENTIALS_CHECK_TOKEN }}
         run: |
           python3 actions/.github/scripts/inventory-escalate.py \
             --tier imminent_T7 --escalations escalations.json
 
       - name: Apply T+0 escalations (SEV-2 incident PR + comment)
         env:
-          GH_TOKEN: ${{ secrets.GH_ISSUE_TOKEN }}
+          GH_TOKEN: ${{ secrets.CREDENTIALS_CHECK_TOKEN }}
         run: |
           python3 actions/.github/scripts/inventory-escalate.py \
             --tier expired_T0 --escalations escalations.json \

--- a/.github/workflows/job-review-request.yml
+++ b/.github/workflows/job-review-request.yml
@@ -91,7 +91,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 jobs:
@@ -409,7 +409,7 @@ jobs:
 
           if [ -s inferred-labels.txt ]; then
             while IFS= read -r label; do
-              if ! gh issue edit "$pr_number" --repo "$repo" --add-label "$label"; then
+              if ! gh api --method POST "repos/${repo}/issues/${pr_number}/labels" -f "labels[]=${label}" >/dev/null; then
                 echo "::warning::Could not apply optional classification label '${label}'. Continuing with Grid review queueing."
               fi
             done < inferred-labels.txt


### PR DESCRIPTION
## Summary
- repoint external credential drift checks at the provisioned `CREDENTIALS_CHECK_TOKEN`
- restore `pull-requests: write` for the reusable Grid review request workflow so PR label writes are permitted
- use the REST labels endpoint for inferred classification labels instead of `gh issue edit` GraphQL behavior

## Verification
- `git diff --check`
- inspected failing Architecture run `26690642216`: label writes were rejected with `Resource not accessible by integration`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated credential validation workflow to use enhanced token-based authentication.
  * Improved pull request classification label application process with updated workflow permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HoneyDrunkStudios/HoneyDrunk.Actions/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->