### PR TITLE
[codex] Close out ADR-0086 local-worker review rollout

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+### Changed
+
+- Recorded the ADR-0086 local-worker Grid review rollout and aligned the Grid review caller permissions with the reusable workflow contract.


### PR DESCRIPTION
## Summary
- Close out ADR-0086 Phase B metadata for the local-worker Grid review rollout.
- Align the Actions repo Grid review caller permission with the reusable workflow contract.
- Add the missing changelog entry for the Actions repo rollout state.

## Validation
- Confirmed .honeydrunk-review.yaml uses unner: local-worker.
- Confirmed this branch changes .github/workflows/pr-review.yml to grant contents: read, pull-requests: write, and issues: write.
- Confirmed the PR template carries the Authorship: line.
- Ran git diff --check.

## Smoke Test
- The Actions repo is the exception in this packet: the PR is fixing the base-branch caller permission that currently causes Grid Review Request to fail at startup, and pull_request_target evaluates the base workflow before this branch can change it.
- After this lands, subsequent Actions PRs should enter the local-worker queue normally.

Authorship: agent-codex
Packet: ADR-0086 packet 09