### PR TITLE
fix(publish): normalize artifact path for upload-artifact@v6

### DIFF
--- a/.github/workflows/job-dotnet-publish-artifact.yml
+++ b/.github/workflows/job-dotnet-publish-artifact.yml
@@ -155,16 +155,16 @@ jobs:
           PUBLISH_OUTPUT: ${{ inputs.publish-output }}
         run: |
           set -euo pipefail
-          # actions/upload-artifact@v6 rejects path patterns containing '.' or
-          # '..' segments (e.g. './publish' or '././publish'). Combine
-          # working-directory + publish-output into a clean, workspace-relative
-          # path with any leading './' stripped.
-          po="${PUBLISH_OUTPUT#./}"
-          combined="${WORKING_DIR%/}/${po}"
-          combined="${combined#./}"
-          combined="${combined#/}"
-          echo "path=${combined}" >> "$GITHUB_OUTPUT"
-          echo "Resolved upload path: ${combined}"
+          # actions/upload-artifact@v6 rejects path patterns containing any '.'
+          # or '..' segment (e.g. './publish', '././publish', 'src/./out').
+          # The publish step ran in WORKING_DIR and wrote to PUBLISH_OUTPUT, so
+          # the files live at <workspace>/<WORKING_DIR>/<PUBLISH_OUTPUT>. Use
+          # realpath -m (collapses every '.'/'..' without requiring the path to
+          # exist) to derive a clean workspace-relative path for upload.
+          abs="$(realpath -m -- "${GITHUB_WORKSPACE}/${WORKING_DIR}/${PUBLISH_OUTPUT}")"
+          rel="$(realpath -m --relative-to="${GITHUB_WORKSPACE}" -- "${abs}")"
+          echo "path=${rel}" >> "$GITHUB_OUTPUT"
+          echo "Resolved upload path: ${rel}"
 
       - name: Upload published artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/job-dotnet-publish-artifact.yml
+++ b/.github/workflows/job-dotnet-publish-artifact.yml
@@ -147,11 +147,30 @@ jobs:
 
           dotnet publish "${ARGS[@]}"
 
+      - name: Resolve artifact path
+        id: artifact-path
+        shell: bash
+        env:
+          WORKING_DIR: ${{ inputs.working-directory }}
+          PUBLISH_OUTPUT: ${{ inputs.publish-output }}
+        run: |
+          set -euo pipefail
+          # actions/upload-artifact@v6 rejects path patterns containing '.' or
+          # '..' segments (e.g. './publish' or '././publish'). Combine
+          # working-directory + publish-output into a clean, workspace-relative
+          # path with any leading './' stripped.
+          po="${PUBLISH_OUTPUT#./}"
+          combined="${WORKING_DIR%/}/${po}"
+          combined="${combined#./}"
+          combined="${combined#/}"
+          echo "path=${combined}" >> "$GITHUB_OUTPUT"
+          echo "Resolved upload path: ${combined}"
+
       - name: Upload published artifact
         uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.artifact-name }}
-          path: ${{ inputs.working-directory }}/${{ inputs.publish-output }}
+          path: ${{ steps.artifact-path.outputs.path }}
           retention-days: 90
           if-no-files-found: error
 


### PR DESCRIPTION
## Summary
Fix a regression in the reusable `job-dotnet-publish-artifact.yml`: `actions/upload-artifact@v6` rejects path patterns containing `.`/`..` segments, but the workflow built the upload `path` as `${{ inputs.working-directory }}/${{ inputs.publish-output }}`. For the common case (`working-directory: .`, `publish-output: ./publish`) that produced **`././publish`**, failing the upload with:

```
Invalid pattern '././publish'. Relative pathing '.' and '..' is not allowed.
```

This broke **every consumer** of this reusable workflow's artifact upload after the v6 bump.

## Fix
Add a `Resolve artifact path` step that combines `working-directory` + `publish-output` and strips leading `./` to produce a clean workspace-relative path; `upload-artifact` consumes that. Normalization verified:

| working-directory | publish-output | result |
|---|---|---|
| `.` | `./publish` | `publish` |
| `.` | `publish` | `publish` |
| `src` | `out` | `src/out` |
| `.` | `./out/sub` | `out/sub` |

## How it surfaced
First real ADR-0033 dev deploy of `Notify.Functions` (HoneyDrunk.Notify): build + tests passed, then the artifact upload failed on `././publish`. The `dotnet publish` output was correct (`…/publish/`) — only the upload path pattern was invalid.

Authorship: agent-claude-code
Out-of-band reason: Control-plane bug fix for upload-artifact@v6 path validation, surfaced by the first ADR-0033 dev deploy; not a packet item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
