### PR TITLE
[codex] Remove OpenClaw review workflow inputs

### DIFF
--- a/.github/workflows/job-review-request.yml
+++ b/.github/workflows/job-review-request.yml
@@ -31,26 +31,6 @@ on:
         required: false
         type: string
         default: '.honeydrunk-review.yaml'
-      openclaw-webhook-url:
-        description: 'Deprecated ADR-0044 input retained for compatibility; local-worker queueing ignores it'
-        required: false
-        type: string
-        default: ''
-      upload-fallback-artifact:
-        description: 'Deprecated ADR-0044 input retained for compatibility; local-worker queueing ignores it'
-        required: false
-        type: boolean
-        default: false
-      post-fallback-comment:
-        description: 'Deprecated ADR-0044 input retained for compatibility; local-worker queueing ignores it'
-        required: false
-        type: boolean
-        default: false
-      artifact-name:
-        description: 'Deprecated ADR-0044 input retained for compatibility; local-worker queueing ignores it'
-        required: false
-        type: string
-        default: 'grid-review-request'
       queue-label:
         description: 'Label that marks a PR as queued for local-worker review'
         required: false
@@ -82,9 +62,6 @@ on:
         type: boolean
         default: true
     secrets:
-      openclaw-webhook-secret:
-        description: 'Deprecated ADR-0044 secret retained for compatibility; local-worker queueing ignores it'
-        required: false
       github-token:
         description: 'GitHub token for PR metadata, labels, and queue comments'
         required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,7 @@
 ### Changed
 
 - Recorded the ADR-0086 local-worker Grid review rollout and aligned the Grid review caller permissions with the reusable workflow contract.
+
+### Removed
+
+- `job-review-request.yml`: removed the deprecated ADR-0044/OpenClaw compatibility inputs (`openclaw-webhook-url`, `upload-fallback-artifact`, `post-fallback-comment`, `artifact-name`) and the no-op `openclaw-webhook-secret` workflow-call secret. The reusable workflow now exposes only the ADR-0086 local-worker queue contract plus `github-token`; the org secret itself is not removed here.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- `job-review-request.yml`: removed the deprecated ADR-0044/OpenClaw compatibility inputs (`openclaw-webhook-url`, `upload-fallback-artifact`, `post-fallback-comment`, `artifact-name`) and the no-op `openclaw-webhook-secret` workflow-call secret. The workflow now exposes only the ADR-0086 local-worker queue contract plus `github-token`; the org secret itself is intentionally left for operator deletion under ADR-0088.
+
 ### Fixed
 
 - `job-sonarcloud.yml`: exclude consumer `.github/workflows/**` wrapper YAML from SonarQube Cloud source analysis by default. The wrapper workflows intentionally call first-party reusable workflows from `HoneyDrunk.Actions@main` so repos receive centralized workflow fixes; SonarCloud reports those new wrapper calls as Security Hotspots even though the executable workflow logic is governed in this repo. Consumers can override the new `sonar-exclusions` input when they intentionally want Sonar to scan workflow YAML.

--- a/docs/consumer-usage.md
+++ b/docs/consumer-usage.md
@@ -354,7 +354,7 @@ It adds `needs-agent-review`, removes stale worker-state completion/claim labels
 
 Set `apply-classification-labels: false` only for a repo that wants the review queue without central PR label classification.
 
-The old OpenClaw webhook inputs are retained as no-op compatibility shims during the cutover, but new callers should not pass them.
+ADR-0088 removed the old OpenClaw webhook compatibility inputs. Callers should pass only the local-worker queue settings and `github-token`.
 
 ---
 


### PR DESCRIPTION
## Summary
- Removes the deprecated ADR-0044/OpenClaw compatibility inputs from `job-review-request.yml`.
- Removes the no-op `openclaw-webhook-secret` workflow-call secret from the reusable workflow interface.
- Updates consumer docs and changelogs to point callers at the ADR-0086 local-worker queue contract only.

Authorship: agent-codex

Packet: HoneyDrunk.Architecture/generated/issue-packets/active/adr-0088-openclaw-decommission/06-actions-remove-deprecated-inputs.md
Out-of-band reason: N/A

## Verification
- `git diff --check`
- Searched for remaining deprecated workflow inputs in `.github/workflows/job-review-request.yml`, `docs/consumer-usage.md`, `CHANGELOG.md`, and `docs/CHANGELOG.md`
- `actionlint` not installed locally; workflow lint could not be run here

Size justification: N/A