### PR TITLE
fix(deploy): Flex Consumption hidden files + correct container revision name

### DIFF
--- a/.github/actions/azure/deploy-container-app/action.yml
+++ b/.github/actions/azure/deploy-container-app/action.yml
@@ -74,12 +74,9 @@ runs:
           --revision-suffix "$SAFE_SUFFIX" \
           --output none
 
+        # SAFE_SUFFIX is already validated non-empty above and APP_NAME is a
+        # required input, so REVISION_NAME is guaranteed non-empty here.
         REVISION_NAME="${APP_NAME}--${SAFE_SUFFIX}"
-
-        if [ -z "$SAFE_SUFFIX" ]; then
-          echo "::error::Container App revision copy did not produce a revision name"
-          exit 1
-        fi
 
         echo "Created revision: $REVISION_NAME"
 

--- a/.github/actions/azure/deploy-container-app/action.yml
+++ b/.github/actions/azure/deploy-container-app/action.yml
@@ -63,16 +63,21 @@ runs:
         fi
 
         echo "Creating Container App revision for $APP_NAME with suffix $SAFE_SUFFIX"
-        REVISION_NAME=$(az containerapp revision copy \
+        # NOTE: `az containerapp revision copy` returns the Container *App*
+        # object (its .name is the app name), NOT the new revision — so we must
+        # not read the revision name from its output. With --revision-suffix the
+        # new revision is deterministically named "<app>--<suffix>".
+        az containerapp revision copy \
           --name "$APP_NAME" \
           --resource-group "$RESOURCE_GROUP" \
           --image "$IMAGE" \
           --revision-suffix "$SAFE_SUFFIX" \
-          --query "name" \
-          --output tsv)
+          --output none
 
-        if [ -z "$REVISION_NAME" ]; then
-          echo "::error::Container App revision copy did not return a revision name"
+        REVISION_NAME="${APP_NAME}--${SAFE_SUFFIX}"
+
+        if [ -z "$SAFE_SUFFIX" ]; then
+          echo "::error::Container App revision copy did not produce a revision name"
           exit 1
         fi
 

--- a/.github/workflows/job-dotnet-publish-artifact.yml
+++ b/.github/workflows/job-dotnet-publish-artifact.yml
@@ -173,6 +173,11 @@ jobs:
           path: ${{ steps.artifact-path.outputs.path }}
           retention-days: 90
           if-no-files-found: error
+          # upload-artifact@v4+ ignores dotfiles/dotfolders by default. .NET
+          # isolated Functions publish output includes a required `.azurefunctions`
+          # directory; without this it is stripped and Flex Consumption deploy
+          # fails with "Cannot find required .azurefunctions directory".
+          include-hidden-files: true
 
       - name: Emit publish outputs
         id: publish-outputs


### PR DESCRIPTION
## Summary
Two control-plane deploy-mechanics bugs, both surfaced by the first real ADR-0033 dev deploys (infra/RBAC is now correct — these are pure mechanics in the reusable deploy path).

### 1. Functions (Flex Consumption) — missing `.azurefunctions`
`func-hd-notify-dev` is a **Flex Consumption** Function App, which requires a `.azurefunctions` directory at the root of the deployment zip. `actions/upload-artifact@v4+` **ignores dotfiles/dotfolders by default**, so the reusable publish workflow stripped `.azurefunctions` from the artifact → deploy failed with `Cannot find required .azurefunctions directory at root level`.
**Fix:** `include-hidden-files: true` on the upload step.

### 2. Containers — wrong revision name from `revision copy`
`deploy-container-app` did `REVISION_NAME=$(az containerapp revision copy … --query name -o tsv)`. But `revision copy` returns the Container **App** object (its `.name` is the *app* name), not the new revision. So the action captured `ca-hd-notify-worker-dev` and the next `revision show --revision ca-hd-notify-worker-dev` threw `ContainerAppInvalidRevisionName`. (The revision itself was created fine — `ca-hd-notify-worker-dev--ca-<run>-<attempt>`.)
**Fix:** run the copy with `--output none` and compute the deterministic name `"<app>--<suffix>"`.

## Evidence
- Functions run: `InvalidPackageContentException … Flex consumption plan is detected.`
- Worker/Collector runs: revision `…--ca-26819571401-1` present & Activating, but workflow failed on `InvalidRevisionName 'ca-hd-notify-worker-dev'`.

Authorship: agent-claude-code
Out-of-band reason: Control-plane deploy-mechanics fixes surfaced by the first real ADR-0033 dev deploys (Flex Consumption packaging + Container Apps revision naming); not a pre-scoped packet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
