### PR TITLE
fix(pr-core): make out-of-band label apply/remove non-fatal

### DIFF
--- a/.github/workflows/pr-core.yml
+++ b/.github/workflows/pr-core.yml
@@ -444,20 +444,28 @@ jobs:
 
           # Labeling is best-effort: the Authorship + Packet/Out-of-band fields in
           # the body (validated and gated above) are the source of truth. Applying
-          # the label needs pull-requests:write, which the default token may lack
-          # (GraphQL "Resource not accessible by integration") — warn instead of
-          # failing the check, so out-of-band PRs aren't blocked on a cosmetic label.
+          # the label can fail for several reasons — the token lacking label write
+          # ("Resource not accessible by integration"), the label not existing, or
+          # a transient API error — none of which should fail this check. Warn
+          # (surfacing gh's own message) instead of exiting, so an out-of-band PR
+          # is never blocked on a cosmetic label.
+          def label_warn_detail(result):
+              tail = (result.stderr or result.stdout or '').strip().splitlines()
+              return tail[-1].strip() if tail else 'no error detail from gh'
+
           if has_oob_reason and not has_label:
-              if gh('pr', 'edit', pr_number, '--repo', repo, '--add-label', 'out-of-band', check=False).returncode == 0:
+              r = gh('pr', 'edit', pr_number, '--repo', repo, '--add-label', 'out-of-band', check=False)
+              if r.returncode == 0:
                   print('Added out-of-band label because the PR declares an Out-of-band reason.')
               else:
-                  print('::warning::Could not apply the out-of-band label (token lacks label write). '
-                        'The Out-of-band reason in the PR body is authoritative; apply the label manually for the visual cue.')
+                  print(f'::warning::Could not apply the out-of-band label (non-fatal): {label_warn_detail(r)}. '
+                        'The Out-of-band reason in the PR body is authoritative; apply the label manually if you want the visual cue.')
           elif has_packet and has_label:
-              if gh('pr', 'edit', pr_number, '--repo', repo, '--remove-label', 'out-of-band', check=False).returncode == 0:
+              r = gh('pr', 'edit', pr_number, '--repo', repo, '--remove-label', 'out-of-band', check=False)
+              if r.returncode == 0:
                   print('Removed out-of-band label because Packet metadata is present.')
               else:
-                  print('::warning::Could not remove the stale out-of-band label (token lacks label write); remove it manually.')
+                  print(f'::warning::Could not remove the stale out-of-band label (non-fatal): {label_warn_detail(r)}. Remove it manually if needed.')
           elif has_oob_reason:
               print('Out-of-band reason present and label already applied.')
           elif has_packet:

--- a/.github/workflows/pr-core.yml
+++ b/.github/workflows/pr-core.yml
@@ -445,8 +445,10 @@ jobs:
           # Label mutation uses `gh issue edit` (the issue-level labels API), which
           # matches this job's `issues: write` permission — `gh pr edit --add-label`
           # goes through the PR GraphQL mutation and would need `pull-requests: write`,
-          # so under our least-privilege grant it would only ever warn. (PRs are
-          # issues for labeling purposes; the large-pr labeling below uses the same
+          # so under our least-privilege grant it fails outright ("Resource not
+          # accessible by integration"); the best-effort handler below only downgrades
+          # that to a warning, so the label is never actually applied. (PRs are issues
+          # for labeling purposes; the large-pr labeling below uses the same
           # `gh issue edit` path.) Even so, labeling stays best-effort: the Authorship
           # + Packet/Out-of-band fields in the body (validated and gated above) are
           # the source of truth. Applying the label can still fail (the label not

--- a/.github/workflows/pr-core.yml
+++ b/.github/workflows/pr-core.yml
@@ -442,26 +442,30 @@ jobs:
           labels = {line.strip() for line in labels_stdout.splitlines() if line.strip()}
           has_label = 'out-of-band' in labels
 
-          # Labeling is best-effort: the Authorship + Packet/Out-of-band fields in
-          # the body (validated and gated above) are the source of truth. Applying
-          # the label can fail for several reasons — the token lacking label write
-          # ("Resource not accessible by integration"), the label not existing, or
-          # a transient API error — none of which should fail this check. Warn
-          # (surfacing gh's own message) instead of exiting, so an out-of-band PR
+          # Label mutation uses `gh issue edit` (the issue-level labels API), which
+          # matches this job's `issues: write` permission — `gh pr edit --add-label`
+          # goes through the PR GraphQL mutation and would need `pull-requests: write`,
+          # so under our least-privilege grant it would only ever warn. (PRs are
+          # issues for labeling purposes; the large-pr labeling below uses the same
+          # `gh issue edit` path.) Even so, labeling stays best-effort: the Authorship
+          # + Packet/Out-of-band fields in the body (validated and gated above) are
+          # the source of truth. Applying the label can still fail (the label not
+          # existing, a transient API error) — none of which should fail this check.
+          # Warn (surfacing gh's own message) instead of exiting, so an out-of-band PR
           # is never blocked on a cosmetic label.
           def label_warn_detail(result):
               tail = (result.stderr or result.stdout or '').strip().splitlines()
               return tail[-1].strip() if tail else 'no error detail from gh'
 
           if has_oob_reason and not has_label:
-              r = gh('pr', 'edit', pr_number, '--repo', repo, '--add-label', 'out-of-band', check=False)
+              r = gh('issue', 'edit', pr_number, '--repo', repo, '--add-label', 'out-of-band', check=False)
               if r.returncode == 0:
                   print('Added out-of-band label because the PR declares an Out-of-band reason.')
               else:
                   print(f'::warning::Could not apply the out-of-band label (non-fatal): {label_warn_detail(r)}. '
                         'The Out-of-band reason in the PR body is authoritative; apply the label manually if you want the visual cue.')
           elif has_packet and has_label:
-              r = gh('pr', 'edit', pr_number, '--repo', repo, '--remove-label', 'out-of-band', check=False)
+              r = gh('issue', 'edit', pr_number, '--repo', repo, '--remove-label', 'out-of-band', check=False)
               if r.returncode == 0:
                   print('Removed out-of-band label because Packet metadata is present.')
               else:

--- a/.github/workflows/pr-core.yml
+++ b/.github/workflows/pr-core.yml
@@ -442,12 +442,22 @@ jobs:
           labels = {line.strip() for line in labels_stdout.splitlines() if line.strip()}
           has_label = 'out-of-band' in labels
 
+          # Labeling is best-effort: the Authorship + Packet/Out-of-band fields in
+          # the body (validated and gated above) are the source of truth. Applying
+          # the label needs pull-requests:write, which the default token may lack
+          # (GraphQL "Resource not accessible by integration") — warn instead of
+          # failing the check, so out-of-band PRs aren't blocked on a cosmetic label.
           if has_oob_reason and not has_label:
-              gh('pr', 'edit', pr_number, '--repo', repo, '--add-label', 'out-of-band')
-              print('Added out-of-band label because the PR declares an Out-of-band reason.')
+              if gh('pr', 'edit', pr_number, '--repo', repo, '--add-label', 'out-of-band', check=False).returncode == 0:
+                  print('Added out-of-band label because the PR declares an Out-of-band reason.')
+              else:
+                  print('::warning::Could not apply the out-of-band label (token lacks label write). '
+                        'The Out-of-band reason in the PR body is authoritative; apply the label manually for the visual cue.')
           elif has_packet and has_label:
-              gh('pr', 'edit', pr_number, '--repo', repo, '--remove-label', 'out-of-band')
-              print('Removed out-of-band label because Packet metadata is present.')
+              if gh('pr', 'edit', pr_number, '--repo', repo, '--remove-label', 'out-of-band', check=False).returncode == 0:
+                  print('Removed out-of-band label because Packet metadata is present.')
+              else:
+                  print('::warning::Could not remove the stale out-of-band label (token lacks label write); remove it manually.')
           elif has_oob_reason:
               print('Out-of-band reason present and label already applied.')
           elif has_packet:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Recorded the ADR-0086 local-worker Grid review rollout and aligned the Grid review caller permissions with the reusable workflow contract.
+- `pr-core.yml`: the PR Metadata check's `out-of-band` label sync is now best-effort (warns instead of failing the check when the label cannot be applied/removed) and uses `gh issue edit` (the issue-level labels API) so it works under the job's least-privilege `issues: write` permission rather than only warning under `pull-requests: read`. The Authorship + Packet/Out-of-band body fields remain the authoritative, gated source of truth; the label is a cosmetic cue.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - Recorded the ADR-0086 local-worker Grid review rollout and aligned the Grid review caller permissions with the reusable workflow contract.
-- `pr-core.yml`: the PR Metadata check's `out-of-band` label sync is now best-effort (warns instead of failing the check when the label cannot be applied/removed) and uses `gh issue edit` (the issue-level labels API) so it works under the job's least-privilege `issues: write` permission rather than only warning under `pull-requests: read`. The Authorship + Packet/Out-of-band body fields remain the authoritative, gated source of truth; the label is a cosmetic cue.
+- `pr-core.yml`: the PR Metadata check's `out-of-band` label sync is now best-effort (warns instead of failing the check when the label cannot be applied/removed) and uses `gh issue edit` (the issue-level labels API) so it works under the job's least-privilege `issues: write` permission. Previously the `gh pr edit` path hard-failed with "Resource not accessible by integration" under `pull-requests: read` (a GraphQL mutation failure the best-effort handler downgraded to a warning, so the label was never actually applied). The Authorship + Packet/Out-of-band body fields remain the authoritative, gated source of truth; the label is a cosmetic cue.
 
 ### Removed
 


### PR DESCRIPTION
## Summary
Make the PR-metadata check's `out-of-band` label apply/remove **non-fatal**.

## Problem
The first out-of-band agent PR through pr-core (HoneyDrunk.Notify #55) **failed the "PR Metadata Check"** — not on its content. The check correctly parsed `Authorship: agent-claude-code` + `Out-of-band reason:`, then tried to auto-apply the `out-of-band` label and hit:
```
GraphQL: Resource not accessible by integration (addLabelsToLabelable)
```
i.e. the default `GITHUB_TOKEN` in this job lacks label-write. PRs using `Packet:` never exercised this path, so it had been latent. As-is it blocks **every** out-of-band PR until someone manually applies the label.

## Fix
The Authorship + (Packet xor Out-of-band) fields in the body are already validated and **gated** earlier in the same job — the label is a cosmetic cue, not the gate. So the add/remove-label calls now run with `check=False` and emit a `::warning::` on failure instead of `exit 1`. When the token *does* have label write, behavior is unchanged (it still labels).

(Alternative considered: grant the job `pull-requests: write` + thread it through every consumer `pr.yml`. Heavier and touches every repo; non-fatal is the minimal, correct fix since the body is the source of truth.)

Authorship: agent-claude-code
Out-of-band reason: Control-plane fix to pr-core surfaced by the first out-of-band PR (#55); not a pre-scoped packet. (This PR will exercise the very path it fixes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
