### PR TITLE
fix(deploy-function): health-check probes defaultHostName (Flex Consumption)

### DIFF
--- a/.github/actions/azure/deploy-function/action.yml
+++ b/.github/actions/azure/deploy-function/action.yml
@@ -56,12 +56,23 @@ runs:
         set -euo pipefail
         APP_NAME="${{ inputs.app-name }}"
         SLOT="${{ inputs.slot-name }}"
+        RG="${{ inputs.resource-group }}"
 
+        # Resolve the real hostname from Azure rather than assuming the bare
+        # "<name>.azurewebsites.net" form. Flex Consumption function apps answer
+        # ONLY on a regional hostname ("<name>-<hash>.<region>-01.azurewebsites.net"),
+        # so the bare form returns no response (HTTP 000) and fails the health
+        # check even when the deploy succeeded. defaultHostName is correct for both
+        # Flex and classic plans; fall back to the constructed form if the lookup
+        # fails (e.g. az not logged in for a no-health-check caller).
         if [ "$SLOT" == "production" ] || [ -z "$SLOT" ]; then
-          echo "url=https://${APP_NAME}.azurewebsites.net" >> "$GITHUB_OUTPUT"
+          HOST=$(az functionapp show --resource-group "$RG" --name "$APP_NAME" --query defaultHostName -o tsv 2>/dev/null || true)
+          [ -z "$HOST" ] && HOST="${APP_NAME}.azurewebsites.net"
         else
-          echo "url=https://${APP_NAME}-${SLOT}.azurewebsites.net" >> "$GITHUB_OUTPUT"
+          HOST=$(az functionapp show --resource-group "$RG" --name "$APP_NAME" --slot "$SLOT" --query defaultHostName -o tsv 2>/dev/null || true)
+          [ -z "$HOST" ] && HOST="${APP_NAME}-${SLOT}.azurewebsites.net"
         fi
+        echo "url=https://${HOST}" >> "$GITHUB_OUTPUT"
 
     - name: Wait for function app startup
       if: ${{ inputs.health-check-url != '' }}
@@ -128,7 +139,10 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        echo "url=https://${{ inputs.app-name }}.azurewebsites.net" >> "$GITHUB_OUTPUT"
+        # Resolve the production hostname from Azure (see "Resolve deployed URL").
+        HOST=$(az functionapp show --resource-group "${{ inputs.resource-group }}" --name "${{ inputs.app-name }}" --query defaultHostName -o tsv 2>/dev/null || true)
+        [ -z "$HOST" ] && HOST="${{ inputs.app-name }}.azurewebsites.net"
+        echo "url=https://${HOST}" >> "$GITHUB_OUTPUT"
 
     - name: Final status
       id: final-status

--- a/.github/actions/azure/deploy-function/action.yml
+++ b/.github/actions/azure/deploy-function/action.yml
@@ -63,14 +63,23 @@ runs:
         # ONLY on a regional hostname ("<name>-<hash>.<region>-01.azurewebsites.net"),
         # so the bare form returns no response (HTTP 000) and fails the health
         # check even when the deploy succeeded. defaultHostName is correct for both
-        # Flex and classic plans; fall back to the constructed form if the lookup
-        # fails (e.g. az not logged in for a no-health-check caller).
+        # Flex and classic plans.
         if [ "$SLOT" == "production" ] || [ -z "$SLOT" ]; then
           HOST=$(az functionapp show --resource-group "$RG" --name "$APP_NAME" --query defaultHostName -o tsv 2>/dev/null || true)
-          [ -z "$HOST" ] && HOST="${APP_NAME}.azurewebsites.net"
+          FALLBACK="${APP_NAME}.azurewebsites.net"
         else
           HOST=$(az functionapp show --resource-group "$RG" --name "$APP_NAME" --slot "$SLOT" --query defaultHostName -o tsv 2>/dev/null || true)
-          [ -z "$HOST" ] && HOST="${APP_NAME}-${SLOT}.azurewebsites.net"
+          FALLBACK="${APP_NAME}-${SLOT}.azurewebsites.net"
+        fi
+
+        if [ -z "$HOST" ]; then
+          # Lookup failed (most likely the Azure CLI isn't authenticated). Fall
+          # back to the constructed hostname so a no-health-check caller still
+          # gets a best-effort deployed-url, but warn loudly: for Flex Consumption
+          # that fallback is NOT a configured hostname, so a health check against
+          # it will false-negative. Accurate resolution requires Azure CLI auth.
+          HOST="$FALLBACK"
+          echo "::warning::Could not resolve defaultHostName for ${APP_NAME} via 'az functionapp show' (is the Azure CLI authenticated?). Falling back to ${HOST} — this is NOT a configured hostname for Flex Consumption apps, so a health check against it may false-negative."
         fi
         echo "url=https://${HOST}" >> "$GITHUB_OUTPUT"
 
@@ -141,7 +150,10 @@ runs:
         set -euo pipefail
         # Resolve the production hostname from Azure (see "Resolve deployed URL").
         HOST=$(az functionapp show --resource-group "${{ inputs.resource-group }}" --name "${{ inputs.app-name }}" --query defaultHostName -o tsv 2>/dev/null || true)
-        [ -z "$HOST" ] && HOST="${{ inputs.app-name }}.azurewebsites.net"
+        if [ -z "$HOST" ]; then
+          HOST="${{ inputs.app-name }}.azurewebsites.net"
+          echo "::warning::Could not resolve defaultHostName for ${{ inputs.app-name }} via 'az functionapp show'; falling back to ${HOST}, which may not route for Flex Consumption apps."
+        fi
         echo "url=https://${HOST}" >> "$GITHUB_OUTPUT"
 
     - name: Final status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Recorded the ADR-0086 local-worker Grid review rollout and aligned the Grid review caller permissions with the reusable workflow contract.
 - `pr-core.yml`: the PR Metadata check's `out-of-band` label sync is now best-effort (warns instead of failing the check when the label cannot be applied/removed) and uses `gh issue edit` (the issue-level labels API) so it works under the job's least-privilege `issues: write` permission. Previously the `gh pr edit` path hard-failed with "Resource not accessible by integration" under `pull-requests: read` (a GraphQL mutation failure the best-effort handler downgraded to a warning, so the label was never actually applied). The Authorship + Packet/Out-of-band body fields remain the authoritative, gated source of truth; the label is a cosmetic cue.
 
+### Fixed
+
+- `actions/azure/deploy-function`: the post-deploy health check now probes the function app's real `defaultHostName` (resolved via `az functionapp show`) instead of the assumed `<name>.azurewebsites.net`. Flex Consumption apps answer only on a regional hostname (`<name>-<hash>.<region>-01.azurewebsites.net`), so the bare form returned HTTP 000 and failed the health check even when the deploy itself succeeded. Falls back to the constructed form when the lookup is unavailable. Applies to both the production-URL and post-swap-URL resolution.
+
 ### Removed
 
 - `job-review-request.yml`: removed the deprecated ADR-0044/OpenClaw compatibility inputs (`openclaw-webhook-url`, `upload-fallback-artifact`, `post-fallback-comment`, `artifact-name`) and the no-op `openclaw-webhook-secret` workflow-call secret. The reusable workflow now exposes only the ADR-0086 local-worker queue contract plus `github-token`; the org secret itself is not removed here.


### PR DESCRIPTION
## Summary
The first real **Notify.Functions** dev deploy through the ADR-0033 pipeline went **red on a false negative**. The package deployed and the worker came up healthy, but the deploy job failed at the post-deploy **health check**: it probed `https://func-hd-notify-dev.azurewebsites.net/api/health` and got **HTTP 000** for the full 120s timeout.

Root cause: the `deploy-function` action builds the probe URL as `https://<app-name>.azurewebsites.net`. **Flex Consumption** function apps answer **only** on a regional hostname (`<name>-<hash>.<region>-01.azurewebsites.net`); the bare-name form is not a configured hostname and returns no response. Confirmed live:

```
enabledHostNames: [func-hd-notify-dev-ayecfwe9evf9agd3.eastus2-01.azurewebsites.net, ...scm...]
https://func-hd-notify-dev.azurewebsites.net/api/health                         -> HTTP 000
https://func-hd-notify-dev-ayecfwe9evf9agd3.eastus2-01.azurewebsites.net/api/health -> HTTP 200 {"status":"Healthy",...}
```

## Change
Resolve the deployed URL from the app's actual `defaultHostName` via `az functionapp show` instead of assuming `<name>.azurewebsites.net`. `defaultHostName` is correct for **both Flex and classic** plans. Falls back to the constructed form if the lookup is unavailable (e.g. a caller that skips the health check and isn't logged into Azure). Applied to both the production-URL resolution and the post-swap-URL resolution. `az` is already available — the calling job runs Azure Login before this action, and the existing slot-swap step already uses `az` with the same `resource-group` input.

## Validation
- `action.yml` parses (YAML lint OK).
- Behavior verified out-of-band against `func-hd-notify-dev`: `defaultHostName` returns the regional name and `/api/health` on it → 200, while the bare name → 000 (the exact failure the deploy job hit).
- Next Notify.Functions deploy will exercise this through the pipeline.

## Notes
This is the last blocker to ADR-0033 going green end-to-end for Notify.Functions — the app is already running the merged fix in dev; this makes the **pipeline** correctly report it. Discovered during ADR-0033 deploy verification.

Authorship: agent-claude-code
Out-of-band reason: Emergent CI/CD bug fix surfaced during ADR-0033 deploy verification; not a pre-scoped packet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)