### PR TITLE
fix(deploy-function): resolve hostname via az resource show (Flex CLI quirk)

### DIFF
--- a/.github/actions/azure/deploy-function/action.yml
+++ b/.github/actions/azure/deploy-function/action.yml
@@ -73,7 +73,7 @@ runs:
           HOST=$(az resource show --resource-group "$RG" --name "$APP_NAME" --resource-type Microsoft.Web/sites --query properties.defaultHostName -o tsv 2>/dev/null || true)
           FALLBACK="${APP_NAME}.azurewebsites.net"
         else
-          HOST=$(az resource show --resource-group "$RG" --name "${APP_NAME}/${SLOT}" --resource-type Microsoft.Web/sites/slots --query properties.defaultHostName -o tsv 2>/dev/null || true)
+          HOST=$(az resource show --resource-group "$RG" --namespace Microsoft.Web --parent "sites/$APP_NAME" --resource-type slots --name "$SLOT" --query properties.defaultHostName -o tsv 2>/dev/null || true)
           FALLBACK="${APP_NAME}-${SLOT}.azurewebsites.net"
         fi
 

--- a/.github/actions/azure/deploy-function/action.yml
+++ b/.github/actions/azure/deploy-function/action.yml
@@ -62,13 +62,18 @@ runs:
         # "<name>.azurewebsites.net" form. Flex Consumption function apps answer
         # ONLY on a regional hostname ("<name>-<hash>.<region>-01.azurewebsites.net"),
         # so the bare form returns no response (HTTP 000) and fails the health
-        # check even when the deploy succeeded. defaultHostName is correct for both
-        # Flex and classic plans.
+        # check even when the deploy succeeded.
+        #
+        # NOTE: use `az resource show` (generic ARM), NOT `az functionapp show` —
+        # the latter returns null for defaultHostName/state/hostNames on Flex
+        # Consumption apps (a CLI quirk), which would silently trigger the fallback.
+        # `az resource show` reads the property straight from ARM and is correct for
+        # both Flex and classic plans.
         if [ "$SLOT" == "production" ] || [ -z "$SLOT" ]; then
-          HOST=$(az functionapp show --resource-group "$RG" --name "$APP_NAME" --query defaultHostName -o tsv 2>/dev/null || true)
+          HOST=$(az resource show --resource-group "$RG" --name "$APP_NAME" --resource-type Microsoft.Web/sites --query properties.defaultHostName -o tsv 2>/dev/null || true)
           FALLBACK="${APP_NAME}.azurewebsites.net"
         else
-          HOST=$(az functionapp show --resource-group "$RG" --name "$APP_NAME" --slot "$SLOT" --query defaultHostName -o tsv 2>/dev/null || true)
+          HOST=$(az resource show --resource-group "$RG" --name "${APP_NAME}/${SLOT}" --resource-type Microsoft.Web/sites/slots --query properties.defaultHostName -o tsv 2>/dev/null || true)
           FALLBACK="${APP_NAME}-${SLOT}.azurewebsites.net"
         fi
 
@@ -79,7 +84,7 @@ runs:
           # that fallback is NOT a configured hostname, so a health check against
           # it will false-negative. Accurate resolution requires Azure CLI auth.
           HOST="$FALLBACK"
-          echo "::warning::Could not resolve defaultHostName for ${APP_NAME} via 'az functionapp show' (is the Azure CLI authenticated?). Falling back to ${HOST} — this is NOT a configured hostname for Flex Consumption apps, so a health check against it may false-negative."
+          echo "::warning::Could not resolve defaultHostName for ${APP_NAME} via 'az resource show' (is the Azure CLI authenticated?). Falling back to ${HOST} — this is NOT a configured hostname for Flex Consumption apps, so a health check against it may false-negative."
         fi
         echo "url=https://${HOST}" >> "$GITHUB_OUTPUT"
 
@@ -148,11 +153,12 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        # Resolve the production hostname from Azure (see "Resolve deployed URL").
-        HOST=$(az functionapp show --resource-group "${{ inputs.resource-group }}" --name "${{ inputs.app-name }}" --query defaultHostName -o tsv 2>/dev/null || true)
+        # Resolve the production hostname from Azure (see "Resolve deployed URL"):
+        # `az resource show`, not `az functionapp show` (null on Flex Consumption).
+        HOST=$(az resource show --resource-group "${{ inputs.resource-group }}" --name "${{ inputs.app-name }}" --resource-type Microsoft.Web/sites --query properties.defaultHostName -o tsv 2>/dev/null || true)
         if [ -z "$HOST" ]; then
           HOST="${{ inputs.app-name }}.azurewebsites.net"
-          echo "::warning::Could not resolve defaultHostName for ${{ inputs.app-name }} via 'az functionapp show'; falling back to ${HOST}, which may not route for Flex Consumption apps."
+          echo "::warning::Could not resolve defaultHostName for ${{ inputs.app-name }} via 'az resource show'; falling back to ${HOST}, which may not route for Flex Consumption apps."
         fi
         echo "url=https://${HOST}" >> "$GITHUB_OUTPUT"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- `actions/azure/deploy-function`: the post-deploy health check now probes the function app's real `defaultHostName` (resolved via `az functionapp show`) instead of the assumed `<name>.azurewebsites.net`. Flex Consumption apps answer only on a regional hostname (`<name>-<hash>.<region>-01.azurewebsites.net`), so the bare form returned HTTP 000 and failed the health check even when the deploy itself succeeded. Falls back to the constructed form when the lookup is unavailable. Applies to both the production-URL and post-swap-URL resolution.
+- `actions/azure/deploy-function`: the post-deploy health check now probes the function app's real `defaultHostName` (resolved via `az resource show --resource-type Microsoft.Web/sites`) instead of the assumed `<name>.azurewebsites.net`. Flex Consumption apps answer only on a regional hostname (`<name>-<hash>.<region>-01.azurewebsites.net`), so the bare form returned HTTP 000 and failed the health check even when the deploy itself succeeded. `az functionapp show` is deliberately avoided here — it returns null for `defaultHostName`/`state`/`hostNames` on Flex Consumption apps (a CLI quirk); `az resource show` reads the property straight from ARM and is correct for both Flex and classic plans. Falls back to the constructed form (with a warning) when the lookup is unavailable. Applies to both the production-URL and post-swap-URL resolution.
 
 ### Removed
 


### PR DESCRIPTION
## Summary
Follow-up to #185. That PR correctly switched the health-check probe to the app's `defaultHostName`, but resolved it with **`az functionapp show`** — which **returns null for `defaultHostName` (and `state`/`hostNames`) on Flex Consumption apps** (a CLI quirk). So on the real Notify.Functions deploy it silently hit the warning/fallback path and re-probed the non-routing bare hostname, failing the health check again:

```
##[warning]Could not resolve defaultHostName for func-hd-notify-dev via 'az functionapp show'...
           Falling back to func-hd-notify-dev.azurewebsites.net
Probing https://func-hd-notify-dev.azurewebsites.net/api/health ... HTTP 000 → fail
```

Verified live which command works:

```
az functionapp show  --query defaultHostName -o tsv          ->  (empty)
az resource show --resource-type Microsoft.Web/sites \
                 --query properties.defaultHostName -o tsv   ->  func-hd-notify-dev-ayecfwe9evf9agd3.eastus2-01.azurewebsites.net
```

## Change
Resolve `defaultHostName` via **`az resource show --resource-type Microsoft.Web/sites`** (generic ARM read — correct for both Flex and classic) instead of `az functionapp show`. Slot path uses the `Microsoft.Web/sites/slots` sub-resource. The fallback + explicit warning (from #185) are retained. Comment updated to explain why `az functionapp show` is deliberately avoided.

## Validation
- `action.yml` parses (YAML lint OK).
- `az resource show ...` returns the correct regional hostname for the live Flex app; `az functionapp show ...` returns empty (the exact failure observed in the deploy job).
- Next Notify.Functions deploy re-run will exercise this through the pipeline.

## Notes
The app itself has been healthy in dev this whole time; this is purely the pipeline's post-deploy verification probing the right hostname via a Flex-correct lookup. Discovered re-running the Notify.Functions deploy after #185 merged.

Authorship: agent-claude-code
Out-of-band reason: Emergent CI/CD bug fix (follow-up to #185) surfaced during ADR-0033 deploy verification; not a pre-scoped packet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)