### PR TITLE
feat(bicep): reusable lint + deploy workflows for ADR-0077 IaC pipeline

### DIFF
--- a/.github/workflows/job-bicep-lint.yml
+++ b/.github/workflows/job-bicep-lint.yml
@@ -1,0 +1,276 @@
+# ==============================================================================
+# Bicep Lint Job
+# ==============================================================================
+# Purpose:
+#   Enforce ADR-0077 D3's Bicep linter gate at PR time. Runs `az bicep lint`
+#   against every changed .bicep file and `az bicep build-params` against every
+#   changed .bicepparam file, then fails the PR on any error-severity linter
+#   finding or any build-params validation error.
+#
+# Single Responsibility:
+#   Bicep validation only — diff-scoped lint + parameter-file build. The naming
+#   and tagging rules themselves live in the consuming repo's bicepconfig.json
+#   (resolved by Bicep's filesystem search); this job just runs the CLI and
+#   adjudicates pass/fail from the SARIF output.
+#
+# Non-goals:
+#   - Deploying Bicep (see job-deploy-bicep.yml).
+#   - Azure authentication — lint runs on source files only, no cloud access.
+#
+# Consumed by:
+#   HoneyDrunk.Infrastructure's pr.yml (where all Bicep content lives per the
+#   ADR-0077 2026-06-02 amendment). Any other repo with Bicep templates can opt
+#   in via the same one-job block — see docs/consumer-usage.md.
+#
+# Behavior:
+#   - Fast skip (exit 0) when the PR touches no .bicep / .bicepparam files.
+#   - `bicep lint` runs on .bicep ONLY (the CLI rejects .bicepparam); .bicepparam
+#     files are validated with `bicep build-params`.
+#   - Fail on error-severity findings; warnings fail only when fail-on-warnings.
+# ==============================================================================
+
+name: Bicep Lint (Job)
+
+on:
+  workflow_call:
+    inputs:
+      paths:
+        description: 'Comma-separated glob patterns to consider. Defaults to all Bicep files in the repo.'
+        required: false
+        type: string
+        default: '**/*.bicep,**/*.bicepparam'
+
+      fail-on-warnings:
+        description: 'Treat warning-severity findings as failures. Default false; tighten per-repo later.'
+        required: false
+        type: boolean
+        default: false
+
+      base-ref:
+        description: >-
+          Optional explicit diff base ref/SHA. When unset, falls back to
+          github.event.pull_request.base.sha then github.event.merge_group.base_sha.
+          Required when the calling workflow_call context does not expose a PR base
+          (e.g. manual dispatch, non-PR triggers).
+        required: false
+        type: string
+        default: ''
+
+      # Accepted but unused — callers that pass actions-ref / runs-on to their
+      # other jobs can include them here without a validation error.
+      actions-ref:
+        description: 'Unused. Accepted for caller compatibility.'
+        required: false
+        type: string
+        default: ''
+      runs-on:
+        description: 'Unused. Bicep lint always runs on ubuntu-latest.'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+
+    outputs:
+      has-warnings:
+        description: 'Whether any warning-severity findings were detected'
+        value: ${{ jobs.bicep-lint.outputs.has-warnings }}
+      warning-messages:
+        description: 'Short summary of findings'
+        value: ${{ jobs.bicep-lint.outputs.warning-messages }}
+
+permissions:
+  contents: read
+
+jobs:
+  bicep-lint:
+    name: Bicep Lint
+    runs-on: ubuntu-latest
+    outputs:
+      has-warnings: ${{ steps.lint.outputs.has-warnings }}
+      warning-messages: ${{ steps.lint.outputs.warning-messages }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve changed Bicep files
+        id: changed
+        shell: bash
+        env:
+          INPUT_BASE_REF: ${{ inputs.base-ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          PATHS: ${{ inputs.paths }}
+        run: |
+          set -euo pipefail
+
+          # --- Resolve the diff base (ADR-0077 packet 07 resolution order) ---
+          if [ -n "$INPUT_BASE_REF" ]; then
+            BASE="$INPUT_BASE_REF"
+          elif [ -n "$PR_BASE_SHA" ]; then
+            BASE="$PR_BASE_SHA"
+          elif [ -n "$MERGE_BASE_SHA" ]; then
+            BASE="$MERGE_BASE_SHA"
+          else
+            echo "::error::Could not resolve a diff base. Pass 'base-ref' explicitly when calling this workflow from a non-PR trigger (manual dispatch, scheduled run, release tag)."
+            exit 1
+          fi
+          echo "Diff base: $BASE"
+          echo "Diff head: $HEAD_SHA"
+
+          # Defensively fetch base + head so the diff is reachable even on a
+          # shallow / merge-ref checkout (mirrors pr-core.yml's pattern).
+          git fetch --no-tags --quiet origin "$BASE" "$HEAD_SHA" 2>/dev/null || true
+
+          # --- Translate the comma-separated glob list into git pathspecs ---
+          # Git pathspecs already match across directories, so `**/` is stripped:
+          #   '**/*.bicep' -> '*.bicep' (matches at any depth).
+          PATHSPECS=()
+          IFS=',' read -ra PATTERNS <<< "$PATHS"
+          for p in "${PATTERNS[@]}"; do
+            p="$(echo "$p" | xargs)"            # trim whitespace
+            [ -z "$p" ] && continue
+            PATHSPECS+=("${p//\*\*\//}")
+          done
+          [ ${#PATHSPECS[@]} -eq 0 ] && PATHSPECS=('*.bicep' '*.bicepparam')
+
+          # --- Compute changed files (three-dot: changes introduced by the PR) ---
+          CHANGED="$(git diff --name-only "${BASE}...${HEAD_SHA}" -- "${PATHSPECS[@]}" || true)"
+
+          : > bicep_files.txt
+          : > bicepparam_files.txt
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            [ -f "$f" ] || continue            # skip deletions
+            case "$f" in
+              *.bicep)      echo "$f" >> bicep_files.txt ;;
+              *.bicepparam) echo "$f" >> bicepparam_files.txt ;;
+            esac
+          done <<< "$CHANGED"
+
+          N_BICEP=$(grep -c . bicep_files.txt || true)
+          N_PARAM=$(grep -c . bicepparam_files.txt || true)
+          echo "Changed .bicep files: $N_BICEP"
+          echo "Changed .bicepparam files: $N_PARAM"
+
+          if [ "$N_BICEP" -eq 0 ] && [ "$N_PARAM" -eq 0 ]; then
+            echo "no Bicep files changed"
+            echo "has-bicep=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-bicep=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Bicep CLI
+        if: steps.changed.outputs.has-bicep == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # az bicep install is idempotent; ensures the latest Bicep on the runner.
+          az bicep install
+          az bicep version
+
+      - name: Lint and validate
+        id: lint
+        if: steps.changed.outputs.has-bicep == 'true'
+        shell: bash
+        env:
+          FAIL_ON_WARNINGS: ${{ inputs.fail-on-warnings }}
+        run: |
+          set -euo pipefail
+          mkdir -p .bicep-lint
+          python3 <<'PY'
+          import json, os, subprocess
+          from pathlib import Path
+
+          fail_on_warnings = os.environ.get('FAIL_ON_WARNINGS', 'false') == 'true'
+
+          def read_list(name):
+              p = Path(name)
+              if not p.exists():
+                  return []
+              return [ln for ln in p.read_text(encoding='utf-8').splitlines() if ln.strip()]
+
+          bicep_files = read_list('bicep_files.txt')
+          param_files = read_list('bicepparam_files.txt')
+
+          findings = []   # (file, source, level, rule, message)
+          errors = 0
+          warnings = 0
+
+          def run(cmd):
+              return subprocess.run(cmd, capture_output=True, text=True)
+
+          # --- Lint each .bicep file (SARIF), adjudicate from the SARIF, not the
+          #     exit code (bicep lint can exit 0 while reporting findings). ---
+          for i, f in enumerate(bicep_files):
+              sarif_path = Path('.bicep-lint') / f'lint-{i}.sarif'
+              proc = run(['az', 'bicep', 'lint', '--file', f, '--diagnostics-format', 'sarif'])
+              sarif_path.write_text(proc.stdout or '', encoding='utf-8')
+              parsed = None
+              try:
+                  parsed = json.loads(proc.stdout) if proc.stdout.strip() else {}
+              except json.JSONDecodeError:
+                  parsed = None
+              if parsed is None:
+                  # No parseable SARIF. If the CLI itself failed, surface it as an error.
+                  if proc.returncode != 0:
+                      msg = (proc.stderr or 'bicep lint failed').strip().splitlines()
+                      findings.append((f, 'lint', 'error', 'cli', msg[-1] if msg else 'bicep lint failed'))
+                      errors += 1
+                  continue
+              for run_obj in parsed.get('runs', []):
+                  for res in run_obj.get('results', []):
+                      level = (res.get('level') or 'warning').lower()
+                      rule = res.get('ruleId') or res.get('rule', {}).get('id') or '(rule)'
+                      message = (res.get('message', {}) or {}).get('text', '').strip()
+                      if level == 'error':
+                          errors += 1
+                      elif level == 'warning':
+                          warnings += 1
+                      findings.append((f, 'lint', level, rule, message))
+
+          # --- Build-params each .bicepparam file; non-zero exit == failure. ---
+          for f in param_files:
+              proc = run(['az', 'bicep', 'build-params', '--file', f, '--stdout'])
+              if proc.returncode != 0:
+                  msg = (proc.stderr or proc.stdout or 'build-params failed').strip().splitlines()
+                  findings.append((f, 'build-params', 'error', 'build-params', msg[-1] if msg else 'build-params failed'))
+                  errors += 1
+
+          # --- Step summary table ---
+          summary = Path(os.environ['GITHUB_STEP_SUMMARY'])
+          with summary.open('a', encoding='utf-8') as s:
+              s.write('## Bicep Lint\n\n')
+              s.write(f'- `.bicep` files linted: **{len(bicep_files)}**\n')
+              s.write(f'- `.bicepparam` files validated: **{len(param_files)}**\n')
+              s.write(f'- Errors: **{errors}** · Warnings: **{warnings}**\n\n')
+              if findings:
+                  s.write('| File | Source | Severity | Rule | Message |\n')
+                  s.write('|------|--------|----------|------|---------|\n')
+                  for f, src, level, rule, message in findings:
+                      msg = message.replace('|', '\\|')
+                      s.write(f'| `{f}` | {src} | {level} | `{rule}` | {msg} |\n')
+              else:
+                  s.write('No findings. ✅\n')
+
+          out = Path(os.environ['GITHUB_OUTPUT'])
+          with out.open('a', encoding='utf-8') as o:
+              o.write(f'has-warnings={"true" if warnings else "false"}\n')
+              o.write(f'warning-messages={warnings} Bicep warning(s), {errors} error(s)\n')
+
+          # --- Verdict ---
+          if errors:
+              print(f'::error::Bicep validation failed: {errors} error-severity finding(s).')
+              raise SystemExit(1)
+          if fail_on_warnings and warnings:
+              print(f'::error::Bicep validation failed: {warnings} warning(s) with fail-on-warnings=true.')
+              raise SystemExit(1)
+          print(f'Bicep validation passed ({warnings} warning(s), 0 blocking).')
+          PY
+
+      - name: No Bicep files changed
+        if: steps.changed.outputs.has-bicep != 'true'
+        shell: bash
+        run: echo "✅ No .bicep / .bicepparam files changed in this PR — Bicep lint skipped."

--- a/.github/workflows/job-bicep-lint.yml
+++ b/.github/workflows/job-bicep-lint.yml
@@ -56,6 +56,12 @@ on:
         type: string
         default: ''
 
+      bicep-version:
+        description: 'Bicep CLI version to install (e.g. v0.37.4). Defaults to latest. Pin for deterministic CI.'
+        required: false
+        type: string
+        default: 'latest'
+
       # Accepted but unused — callers that pass actions-ref / runs-on to their
       # other jobs can include them here without a validation error.
       actions-ref:
@@ -93,6 +99,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve changed Bicep files
         id: changed
@@ -137,7 +144,12 @@ jobs:
           [ ${#PATHSPECS[@]} -eq 0 ] && PATHSPECS=('*.bicep' '*.bicepparam')
 
           # --- Compute changed files (three-dot: changes introduced by the PR) ---
-          CHANGED="$(git diff --name-only "${BASE}...${HEAD_SHA}" -- "${PATHSPECS[@]}" || true)"
+          # Fail closed: a diff-resolution failure must NOT masquerade as
+          # "no Bicep files changed" and silently skip the gate.
+          if ! CHANGED="$(git diff --name-only "${BASE}...${HEAD_SHA}" -- "${PATHSPECS[@]}")"; then
+            echo "::error::git diff failed for '${BASE}...${HEAD_SHA}'. Cannot determine changed Bicep files; failing closed. On a non-PR trigger, pass an explicit, fetchable 'base-ref'."
+            exit 1
+          fi
 
           : > bicep_files.txt
           : > bicepparam_files.txt
@@ -165,10 +177,16 @@ jobs:
       - name: Install Bicep CLI
         if: steps.changed.outputs.has-bicep == 'true'
         shell: bash
+        env:
+          BICEP_VERSION: ${{ inputs.bicep-version }}
         run: |
           set -euo pipefail
-          # az bicep install is idempotent; ensures the latest Bicep on the runner.
-          az bicep install
+          # Pin when a version is supplied (deterministic CI); else install latest.
+          if [ -n "$BICEP_VERSION" ] && [ "$BICEP_VERSION" != "latest" ]; then
+            az bicep install --version "$BICEP_VERSION"
+          else
+            az bicep install
+          fi
           az bicep version
 
       - name: Lint and validate

--- a/.github/workflows/job-deploy-bicep.yml
+++ b/.github/workflows/job-deploy-bicep.yml
@@ -1,0 +1,261 @@
+# ==============================================================================
+# Deploy Bicep Job
+# ==============================================================================
+# Purpose:
+#   Apply a Bicep template from HoneyDrunk.Infrastructure to Azure, per ADR-0077
+#   D4 (as amended 2026-06-02). Runs a bicep build + lint + what-if preflight,
+#   then `az deployment {group|sub} create`. The deploy *pipeline* lives in
+#   HoneyDrunk.Actions per ADR-0012; the Bicep *content* lives in
+#   HoneyDrunk.Infrastructure and is checked out by the caller.
+#
+# Single Responsibility:
+#   Deploy one Bicep template for one environment. Scope-pure.
+#
+# Module resolution:
+#   LOCAL RELATIVE PATH ONLY. Modules (modules/{concern}/{name}.bicep) are
+#   co-located with their consumers in the HoneyDrunk.Infrastructure checkout,
+#   so `bicep build` resolves them from the filesystem. There is NO Bicep
+#   registry, NO `az acr login`, NO `br:acrhdbicep.azurecr.io/...` resolution —
+#   the cross-repo module registry was dropped by the ADR-0077 amendment.
+#
+# Parameter files:
+#   `parameters-path` is a .bicepparam file whose `using` directive points at
+#   the template. Azure CLI deploys it with `--parameters <file>.bicepparam`
+#   and NO `--template-file` (passing both errors with "Only a .bicep file is
+#   allowed with a .bicepparam file"). `template-path` is used for the
+#   build/lint preflight only.
+#
+# Caller responsibilities (NOT handled here — this workflow is scope-pure):
+#   - Declare the `environment:` approval gate (ADR-0033) on the calling job.
+#   - Declare a `permissions:` superset of this workflow's needs (invariant 39):
+#       id-token: write   (OIDC federation)
+#       contents: read    (checkout)
+#   - Provide the OIDC federated identity inputs (azure-client-id / -tenant-id /
+#     -subscription-id). The deploy identity provisions resources; it does NOT
+#     read secret values (invariant 8 / ADR-0077 D7).
+# ==============================================================================
+
+name: Deploy Bicep (Job)
+
+on:
+  workflow_call:
+    inputs:
+      env:
+        description: 'Target environment (dev, staging, prod). Used for the deployment name and logging.'
+        required: true
+        type: string
+
+      template-path:
+        description: 'Path to the Bicep template (relative to the caller checkout), e.g. nodes/identity/main.bicep. Used for the build/lint preflight.'
+        required: true
+        type: string
+
+      parameters-path:
+        description: 'Path to the .bicepparam file (relative to the caller checkout), e.g. nodes/identity/parameters.dev.bicepparam. Drives what-if + apply via its `using` directive.'
+        required: true
+        type: string
+
+      deployment-scope:
+        description: 'Deployment scope: resourceGroup or subscription.'
+        required: false
+        type: string
+        default: 'resourceGroup'
+
+      resource-group:
+        description: 'Target resource group. Required when deployment-scope is resourceGroup.'
+        required: false
+        type: string
+        default: ''
+
+      location:
+        description: 'Azure region for deployment metadata. Required when deployment-scope is subscription.'
+        required: false
+        type: string
+        default: ''
+
+      azure-client-id:
+        description: 'Azure AD application (client) ID for OIDC federation.'
+        required: true
+        type: string
+
+      azure-tenant-id:
+        description: 'Azure AD tenant ID for OIDC federation.'
+        required: true
+        type: string
+
+      azure-subscription-id:
+        description: 'Azure subscription ID for OIDC federation.'
+        required: true
+        type: string
+
+    outputs:
+      deployment-name:
+        description: 'The name of the deployment that was created.'
+        value: ${{ jobs.deploy-bicep.outputs.deployment-name }}
+      outputs-json:
+        description: 'The deployment outputs as a JSON object.'
+        value: ${{ jobs.deploy-bicep.outputs.outputs-json }}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy-bicep:
+    name: Deploy Bicep
+    runs-on: ubuntu-latest
+    outputs:
+      deployment-name: ${{ steps.apply.outputs.deployment-name }}
+      outputs-json: ${{ steps.apply.outputs.outputs-json }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Validate inputs
+        id: validate
+        shell: bash
+        env:
+          SCOPE: ${{ inputs.deployment-scope }}
+          RG: ${{ inputs.resource-group }}
+          LOCATION: ${{ inputs.location }}
+          TEMPLATE: ${{ inputs.template-path }}
+          PARAMS: ${{ inputs.parameters-path }}
+        run: |
+          set -euo pipefail
+
+          case "$SCOPE" in
+            resourceGroup)
+              if [ -z "$RG" ]; then
+                echo "::error::deployment-scope is 'resourceGroup' but 'resource-group' input is empty."
+                exit 1
+              fi
+              ;;
+            subscription)
+              if [ -z "$LOCATION" ]; then
+                echo "::error::deployment-scope is 'subscription' but 'location' input is empty."
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::deployment-scope must be 'resourceGroup' or 'subscription' (got '$SCOPE')."
+              exit 1
+              ;;
+          esac
+
+          if [ ! -f "$TEMPLATE" ]; then
+            echo "::error::Template not found at '$TEMPLATE' (relative to the caller checkout)."
+            exit 1
+          fi
+          if [ ! -f "$PARAMS" ]; then
+            echo "::error::Parameters file not found at '$PARAMS' (relative to the caller checkout)."
+            exit 1
+          fi
+          echo "Template:   $TEMPLATE"
+          echo "Parameters: $PARAMS"
+          echo "Scope:      $SCOPE"
+
+      - name: Install Bicep CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          az bicep install
+          az bicep version
+
+      - name: Preflight - bicep build + lint
+        shell: bash
+        env:
+          TEMPLATE: ${{ inputs.template-path }}
+        run: |
+          set -euo pipefail
+          # build compiles the template and resolves local-path modules from the
+          # checkout — a hard gate on compile errors. No registry restore needed.
+          echo "::group::bicep build (compile + local-module resolution)"
+          az bicep build --file "$TEMPLATE" --stdout > /dev/null
+          echo "::endgroup::"
+          # lint surfaces D3 naming/tagging + secret-hygiene findings from the
+          # infra repo's root bicepconfig.json. Informational here; the hard
+          # lint gate is the PR-time job-bicep-lint.yml.
+          echo "::group::bicep lint"
+          az bicep lint --file "$TEMPLATE" || true
+          echo "::endgroup::"
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ inputs.azure-client-id }}
+          tenant-id: ${{ inputs.azure-tenant-id }}
+          subscription-id: ${{ inputs.azure-subscription-id }}
+
+      - name: What-if preflight
+        shell: bash
+        env:
+          SCOPE: ${{ inputs.deployment-scope }}
+          RG: ${{ inputs.resource-group }}
+          LOCATION: ${{ inputs.location }}
+          PARAMS: ${{ inputs.parameters-path }}
+          ENV: ${{ inputs.env }}
+        run: |
+          set -euo pipefail
+          # NOTE: with a .bicepparam file, pass ONLY --parameters (the `using`
+          # directive resolves the template). Adding --template-file errors with
+          # "Only a .bicep file is allowed with a .bicepparam file."
+          echo "::group::az deployment what-if"
+          if [ "$SCOPE" = "resourceGroup" ]; then
+            az deployment group what-if \
+              --resource-group "$RG" \
+              --parameters "$PARAMS"
+          else
+            az deployment sub what-if \
+              --location "$LOCATION" \
+              --parameters "$PARAMS"
+          fi
+          echo "::endgroup::"
+
+      - name: Apply deployment
+        id: apply
+        shell: bash
+        env:
+          SCOPE: ${{ inputs.deployment-scope }}
+          RG: ${{ inputs.resource-group }}
+          LOCATION: ${{ inputs.location }}
+          PARAMS: ${{ inputs.parameters-path }}
+          ENV: ${{ inputs.env }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          DEPLOY_NAME="hd-infra-${ENV}-${RUN_ID}-${RUN_ATTEMPT}"
+          echo "Deployment name: $DEPLOY_NAME"
+
+          if [ "$SCOPE" = "resourceGroup" ]; then
+            OUTPUTS=$(az deployment group create \
+              --name "$DEPLOY_NAME" \
+              --resource-group "$RG" \
+              --parameters "$PARAMS" \
+              --query 'properties.outputs' -o json)
+          else
+            OUTPUTS=$(az deployment sub create \
+              --name "$DEPLOY_NAME" \
+              --location "$LOCATION" \
+              --parameters "$PARAMS" \
+              --query 'properties.outputs' -o json)
+          fi
+
+          echo "deployment-name=$DEPLOY_NAME" >> "$GITHUB_OUTPUT"
+          # Emit outputs as a compact single-line JSON for the workflow output.
+          COMPACT=$(printf '%s' "$OUTPUTS" | tr -d '\n' | tr -s ' ')
+          echo "outputs-json=$COMPACT" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Bicep Deployment"
+            echo ""
+            echo "- Environment: \`${ENV}\`"
+            echo "- Scope: \`${SCOPE}\`"
+            echo "- Deployment: \`${DEPLOY_NAME}\`"
+            echo ""
+            echo "Outputs:"
+            echo '```json'
+            printf '%s\n' "$OUTPUTS"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/job-deploy-bicep.yml
+++ b/.github/workflows/job-deploy-bicep.yml
@@ -88,6 +88,12 @@ on:
         required: true
         type: string
 
+      bicep-version:
+        description: 'Bicep CLI version to install (e.g. v0.37.4). Defaults to latest. Pin for deterministic CI.'
+        required: false
+        type: string
+        default: 'latest'
+
     outputs:
       deployment-name:
         description: 'The name of the deployment that was created.'
@@ -111,6 +117,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Validate inputs
         id: validate
@@ -157,9 +165,16 @@ jobs:
 
       - name: Install Bicep CLI
         shell: bash
+        env:
+          BICEP_VERSION: ${{ inputs.bicep-version }}
         run: |
           set -euo pipefail
-          az bicep install
+          # Pin when a version is supplied (deterministic CI); else install latest.
+          if [ -n "$BICEP_VERSION" ] && [ "$BICEP_VERSION" != "latest" ]; then
+            az bicep install --version "$BICEP_VERSION"
+          else
+            az bicep install
+          fi
           az bicep version
 
       - name: Preflight - bicep build + lint
@@ -243,8 +258,10 @@ jobs:
           fi
 
           echo "deployment-name=$DEPLOY_NAME" >> "$GITHUB_OUTPUT"
-          # Emit outputs as a compact single-line JSON for the workflow output.
-          COMPACT=$(printf '%s' "$OUTPUTS" | tr -d '\n' | tr -s ' ')
+          # Emit outputs as compact single-line JSON. Use jq (JSON-aware): a
+          # naive `tr -s ' '` would collapse spaces inside string values and
+          # corrupt the payload.
+          COMPACT=$(printf '%s' "$OUTPUTS" | jq -c .)
           echo "outputs-json=$COMPACT" >> "$GITHUB_OUTPUT"
 
           {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- `job-deploy-bicep.yml`: new reusable (`workflow_call`) deploy workflow for the ADR-0077 Bicep pipeline (supersedes the never-shipped packet 06 design). Applies a template from `HoneyDrunk.Infrastructure` via `az deployment {group|sub} create` with OIDC federation (`azure/login@v3`, `id-token: write`; no `AZURE_CREDENTIALS` secret). Inputs: `env`, `template-path`, `parameters-path`, `deployment-scope` (resourceGroup|subscription), `resource-group`, `location`, plus the three `azure-*` OIDC ids. Runs `bicep build` + `bicep lint` + `az deployment ... what-if` as preflight before apply. Modules resolve by **local relative path** — no `az acr login`, no `br:` refs, no `acrhdbicep` (registry dropped by the 2026-06-02 amendment). `.bicepparam` files deploy via `--parameters` alone (no `--template-file`, which the CLI rejects alongside a `.bicepparam`). Scope-pure: the caller declares the ADR-0033 `environment:` gate and the invariant-39 `permissions:` superset.
+- `job-bicep-lint.yml`: new reusable (`workflow_call`) workflow implementing the ADR-0077 D3 Bicep linter gate. Diff-scopes changed `.bicep` / `.bicepparam` files (base resolved from `base-ref` → `pull_request.base.sha` → `merge_group.base_sha`), runs `az bicep lint --diagnostics-format sarif` on templates and `az bicep build-params` on parameter files, and fails the PR on any error-severity finding or build-params failure (warnings opt-in via `fail-on-warnings`). Fast-skips with exit 0 when a PR touches no Bicep. `permissions: contents: read` only — no Azure auth. Opt-in by inclusion; the canonical consumer is `HoneyDrunk.Infrastructure`'s `pr.yml`. See `docs/consumer-usage.md` → "Bicep Lint Workflow". (ADR-0077 packet 07; not wired into the shared `pr-core.yml` because, post the 2026-06-02 consolidation amendment, all Bicep content lives in `HoneyDrunk.Infrastructure`, not Actions.)
+
 ### Changed
 
 - Recorded the ADR-0086 local-worker Grid review rollout and aligned the Grid review caller permissions with the reusable workflow contract.

--- a/docs/consumer-usage.md
+++ b/docs/consumer-usage.md
@@ -38,6 +38,8 @@ For workflows not explicitly listed in ADR-0012 D5, the baseline is derived from
 
 - [Caller permissions — the load-bearing rule](#caller-permissions--the-load-bearing-rule)
 - [PR Core Workflow](#pr-core-workflow)
+- [Bicep Lint Workflow](#bicep-lint-workflow)
+- [Deploy Bicep Workflow](#deploy-bicep-workflow)
 - [SonarQube Cloud Quality Gate](#sonarqube-cloud-quality-gate)
 - [PR SDK Workflow](#pr-sdk-workflow)
 - [Grid Review Request Workflow](#grid-review-request-workflow)
@@ -297,6 +299,98 @@ jobs:
 
 `pr-core.yml` callers need an explicit top-level or job-level permissions block that grants `contents: read`, `checks: write`, `pull-requests: write`, `security-events: write`, and `issues: write`. `issues: write` is part of the baseline because PR metadata/size checks maintain labels and comments. Under `workflow_call`, the callee declaration is documentary, so missing or under-granted caller permissions fail at workflow-load time and later surface through grid-health as Stale. Extra scopes are allowed only when another job in the same workflow needs them; prefer least privilege.
 
+
+## Bicep Lint Workflow
+
+**Purpose:** Enforce ADR-0077 D3's Bicep linter gate at PR time. Runs `az bicep lint` against every changed `.bicep` file and `az bicep build-params` against every changed `.bicepparam` file, then fails the PR on any error-severity linter finding or any parameter-file validation error.
+
+**When to Use:** Any repo that holds Bicep templates. The gate is **opt-in by inclusion** — a repo with no Bicep files does not wire it. The canonical consumer is `HoneyDrunk.Infrastructure`, where all Grid Bicep content lives (`modules/`, `platform/`, `nodes/`) per the ADR-0077 2026-06-02 amendment. The naming/tagging linter rules live in the consuming repo's root `bicepconfig.json` (resolved by Bicep's filesystem search); this workflow just runs the CLI and adjudicates pass/fail from the SARIF output.
+
+### Minimal Caller
+
+```yaml
+# .github/workflows/pr.yml (in the consuming repo)
+jobs:
+  bicep-lint:
+    name: Bicep Lint
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-bicep-lint.yml@main
+```
+
+That single block is the whole opt-in. On a `pull_request` event the workflow resolves the diff base from `github.event.pull_request.base.sha` automatically.
+
+### Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `paths` | `**/*.bicep,**/*.bicepparam` | Comma-separated glob patterns to consider. |
+| `fail-on-warnings` | `false` | Treat warning-severity findings as failures. Tighten per-repo once the template set is clean. |
+| `base-ref` | `''` | Explicit diff base. **Required** when the calling workflow runs on a non-PR trigger (manual dispatch, scheduled run, release tag), because `github.event.pull_request.base.sha` is absent there. Pass e.g. `base-ref: ${{ github.event.pull_request.base.sha }}` or any ref appropriate to the flow. |
+
+### Behavior
+
+- **Fast skip:** a PR that touches no `.bicep` / `.bicepparam` files exits `0` in seconds — the gate adds zero cost to non-IaC PRs.
+- **Two CLI surfaces:** `bicep lint` runs on `.bicep` files only (the CLI rejects `.bicepparam`); `.bicepparam` files are validated with `bicep build-params`, which type-checks the parameter file against its referenced template.
+- **Verdict:** any `error`-severity lint finding or any `build-params` failure fails the PR. `warning`-severity findings are surfaced in the step summary but pass unless `fail-on-warnings: true`.
+- A per-file findings table (file · source · severity · rule · message) is written to the job step summary.
+
+### Permissions
+
+`contents: read` only. The lint job runs against source files and needs no Azure authentication — it never touches the cloud.
+
+## Deploy Bicep Workflow
+
+**Purpose:** Apply a Bicep template from `HoneyDrunk.Infrastructure` to Azure (ADR-0077 D4, as amended). Runs a `bicep build` + `bicep lint` + `az deployment ... what-if` preflight, then `az deployment {group|sub} create`. The deploy *pipeline* lives in Actions per ADR-0012; the Bicep *content* lives in `HoneyDrunk.Infrastructure` and is checked out by the caller.
+
+**When to Use:** From `HoneyDrunk.Infrastructure`'s deploy workflows, one call per environment per template. Modules resolve by **local relative path** within the infra checkout — there is no Bicep registry, no `az acr login`, no `br:` references (the cross-repo registry was dropped by the 2026-06-02 amendment).
+
+### Minimal Caller
+
+```yaml
+# .github/workflows/deploy.yml (in HoneyDrunk.Infrastructure)
+jobs:
+  deploy-identity-dev:
+    name: Deploy Identity (dev)
+    environment: dev            # ADR-0033 approval gate — declared by the CALLER
+    permissions:
+      id-token: write           # OIDC federation
+      contents: read            # checkout
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-deploy-bicep.yml@main
+    with:
+      env: dev
+      template-path: nodes/identity/main.bicep
+      parameters-path: nodes/identity/parameters.dev.bicepparam
+      deployment-scope: resourceGroup
+      resource-group: rg-hd-identity-dev
+      azure-client-id: ${{ vars.AZURE_CLIENT_ID }}
+      azure-tenant-id: ${{ vars.AZURE_TENANT_ID }}
+      azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+```
+
+### Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| `env` | yes | Target environment (`dev`, `staging`, `prod`). Used for the deployment name + logging. |
+| `template-path` | yes | Bicep template path relative to the caller checkout. Used for the build/lint preflight. |
+| `parameters-path` | yes | `.bicepparam` path relative to the caller checkout. Drives what-if + apply via its `using` directive. |
+| `deployment-scope` | no (`resourceGroup`) | `resourceGroup` or `subscription`. |
+| `resource-group` | when scope=`resourceGroup` | Target resource group. |
+| `location` | when scope=`subscription` | Region for deployment metadata. |
+| `azure-client-id` / `azure-tenant-id` / `azure-subscription-id` | yes | OIDC federated identity. The deploy identity provisions resources; it does **not** read secret values (invariant 8 / ADR-0077 D7). |
+
+### Behavior and contract
+
+- **Scope-pure.** The reusable workflow does **not** declare the `environment:` gate — the **caller** does (ADR-0033). This keeps the approval policy with the consumer.
+- **`.bicepparam` only on apply.** The template is resolved from the param file's `using` directive; the workflow passes `--parameters <file>.bicepparam` with **no** `--template-file` (the CLI rejects both together).
+- **what-if before apply.** The diff is printed to the job log — this is the safety surface for the D6 grandfather/import path (an unexpected delete shows up before the apply runs).
+- **No secrets.** OIDC only; no `AZURE_CREDENTIALS`. No secret values enter the workflow or its logs.
+
+### Permissions
+
+Callers need `id-token: write` (OIDC) and `contents: read` (checkout) — a superset of the reusable workflow's declared permissions (invariant 39).
 
 ## Grid Review Request Workflow
 

--- a/docs/consumer-usage.md
+++ b/docs/consumer-usage.md
@@ -327,7 +327,8 @@ That single block is the whole opt-in. On a `pull_request` event the workflow re
 |-------|---------|-------------|
 | `paths` | `**/*.bicep,**/*.bicepparam` | Comma-separated glob patterns to consider. |
 | `fail-on-warnings` | `false` | Treat warning-severity findings as failures. Tighten per-repo once the template set is clean. |
-| `base-ref` | `''` | Explicit diff base. **Required** when the calling workflow runs on a non-PR trigger (manual dispatch, scheduled run, release tag), because `github.event.pull_request.base.sha` is absent there. Pass e.g. `base-ref: ${{ github.event.pull_request.base.sha }}` or any ref appropriate to the flow. |
+| `bicep-version` | `latest` | Bicep CLI version to install (e.g. `v0.37.4`). Pin for deterministic CI. |
+| `base-ref` | `''` | Explicit diff base. PR runs can omit it (auto-resolved from `pull_request.base.sha`). **Required** on non-PR triggers (manual dispatch, scheduled run, release tag), where the PR base is absent — pass a branch like `main` or an explicit commit SHA. |
 
 ### Behavior
 
@@ -380,6 +381,7 @@ jobs:
 | `resource-group` | when scope=`resourceGroup` | Target resource group. |
 | `location` | when scope=`subscription` | Region for deployment metadata. |
 | `azure-client-id` / `azure-tenant-id` / `azure-subscription-id` | yes | OIDC federated identity. The deploy identity provisions resources; it does **not** read secret values (invariant 8 / ADR-0077 D7). |
+| `bicep-version` | no (`latest`) | Bicep CLI version to install (e.g. `v0.37.4`). Pin for deterministic CI. |
 
 ### Behavior and contract
 


### PR DESCRIPTION
## Summary

Adds the **Actions-side half** of the ADR-0077 Bicep pipeline. The pipeline stays in `HoneyDrunk.Actions` per ADR-0012; all Bicep *content* lives in `HoneyDrunk.Infrastructure` per the 2026-06-02 consolidation amendment, so these two workflows are reusable and consumed from that repo. This single commit lands **both** Actions-targeted packets for the initiative.

| Packet | Issue | Deliverable |
|---|---|---|
| 07 | Actions#122 | `job-bicep-lint.yml` — PR-time `bicep lint` + `build-params` gate |
| 16 | Actions#187 | `job-deploy-bicep.yml` — OIDC deploy workflow with what-if preflight |

### `job-bicep-lint.yml` (packet 07)
- Diff-scopes changed `.bicep` / `.bicepparam` files (base resolved `base-ref` → `pull_request.base.sha` → `merge_group.base_sha`; hard-fail if none).
- `az bicep lint --diagnostics-format sarif` on templates; `az bicep build-params --stdout` on param files (the `lint` subcommand rejects `.bicepparam`).
- Fails on any error-severity finding or build-params failure; `warning` opt-in via `fail-on-warnings`. Per-file findings table in the step summary.
- Fast-skips with exit 0 on no-Bicep PRs. `permissions: contents: read` only — no Azure auth.
- **Opt-in by inclusion.** Consumed by `HoneyDrunk.Infrastructure`'s `pr.yml`. Deliberately **not** wired into the shared `pr-core.yml`: post-consolidation Actions has zero `.bicep` files and `pr-core` is Grid-wide, so wiring it there would push a permanently-no-op job onto every repo's PRs.

### `job-deploy-bicep.yml` (packet 16, supersedes the never-shipped packet 06)
- OIDC federation (`azure/login@v3`, `id-token: write`); no `AZURE_CREDENTIALS` secret.
- `bicep build` + `bicep lint` + `az deployment ... what-if` preflight, then `az deployment {group|sub} create`.
- **Local relative-path module resolution** — no registry, no `az acr login`, no `br:` refs, no `acrhdbicep` (registry dropped by the amendment).
- `.bicepparam` applied via `--parameters` **only** (the CLI rejects `--template-file` alongside a `.bicepparam`; the `using` directive resolves the template).
- Scope-pure: the **caller** declares the ADR-0033 `environment:` gate and the invariant-39 `permissions:` superset.

### Docs / changelog
- `docs/consumer-usage.md`: new "Bicep Lint Workflow" + "Deploy Bicep Workflow" sections (ToC, minimal callers, inputs/behavior/permissions).
- `CHANGELOG.md`: `Added` entries for both workflows.

## Verification
- YAML well-formedness + embedded-Python compile validated locally.
- Registry-free + no-`--template-file` constraint guards pass.
- `az bicep lint --diagnostics-format sarif`, `az bicep build-params --stdout`, and the `.bicepparam`-without-`--template-file` rule all confirmed against live Microsoft Learn docs.
- Live-runner behavior (`az bicep` execution) exercises on the first real PR in `HoneyDrunk.Infrastructure` — `az bicep` is not installed in the authoring environment.

## Human follow-up (packet 16)
- Confirm the Actions OIDC deploy identity has Contributor (or scoped equivalent) on the infra resource groups (`rg-hd-{node}-{env}`, `rg-hd-platform-{env}`). Same identity used for container deploys.

Authorship: agent-claude-code
Packet: Actions#122, Actions#187
Size justification: Two reusable workflow definitions (lint + deploy) landed together per operator instruction to consolidate all ADR-0077 Actions work into one commit; both are net-new YAML + their consumer docs, no logic split across files.