### PR TITLE
chore(config): map HoneyDrunk.Infrastructure to honeydrunk-infrastructure (ADR-0077 invariant-102 item 6)

### DIFF
--- a/.github/config/repo-to-node.yml
+++ b/.github/config/repo-to-node.yml
@@ -10,6 +10,7 @@ HoneyDrunk.Notify: honeydrunk-notify
 HoneyDrunk.Communications: honeydrunk-communications
 HoneyDrunk.Actions: honeydrunk-actions
 HoneyDrunk.Architecture: honeydrunk-architecture
+HoneyDrunk.Infrastructure: honeydrunk-infrastructure
 HoneyDrunk.Standards: honeydrunk-standards
 HoneyDrunkStudios: honeydrunk-studios
 HoneyDrunk.Lore: honeydrunk-lore


### PR DESCRIPTION
## Summary

Adds the `HoneyDrunk.Infrastructure: honeydrunk-infrastructure` row to `.github/config/repo-to-node.yml` — **invariant 102 item 6** (the repo→node mapping) for the new IaC-content Node registered by ADR-0077.

This is the **Actions-side** piece of the Node-standup Phase A. The catalog rows + context folder land in the Architecture companion PR (**Architecture#583**, packet 10). With this mapping in place, grid-health aggregation and the Grid review tooling resolve the new repo to its `honeydrunk-infrastructure` node id.

One-line, mechanical; no workflow behavior changes.

**Merge order:** land **Architecture#583** (Node registration) first, then this — the mapping points at a node id that #583 introduces to the catalogs. (The Grid review correctly flagged this ordering; it is by design.)

Authorship: agent-claude-code
Out-of-band reason: Invariant-102 item 6 (the repo→node mapping) lives in HoneyDrunk.Actions but has no dedicated Actions-targeted packet — the ADR-0077 dispatch fuzzed it between packet 10 (Architecture catalogs) and packet 12. Filing this one-line config change out-of-band with the companion registration tracked as Architecture#583.