### PR TITLE
chore: map HoneyDrunk.Evals to honeydrunk-evals in repo-to-node.yml

### DIFF
--- a/.github/config/repo-to-node.yml
+++ b/.github/config/repo-to-node.yml
@@ -23,3 +23,4 @@ HoneyDrunk.Capabilities: honeydrunk-capabilities
 HoneyDrunk.Flow: honeydrunk-flow
 HoneyDrunk.Operator: honeydrunk-operator
 HoneyDrunk.Audit: honeydrunk-audit
+HoneyDrunk.Evals: honeydrunk-evals


### PR DESCRIPTION
Authorship: agent-claude-code
Packet: generated/issue-packets/active/adr-0023-evals-standup/01-architecture-evals-catalog-registration.md

Adds the missing `HoneyDrunk.Evals: honeydrunk-evals` entry to `.github/config/repo-to-node.yml` — mandatory node-standup step 7 (invariant 102) for the **ADR-0023** Evals standup.

`HoneyDrunk.Operator` and `HoneyDrunk.Audit` were already mapped.

Pairs with the Architecture (ADR acceptance + catalog reconciliation), Operator (ADR-0018 scaffold), and Evals (ADR-0023 scaffold) PRs on the same branch.

https://claude.ai/code/session_019KoL9gxKvCtPh5XBM2uweX