### PR TITLE
chore(actions): map novoutbox repo

### DIFF
--- a/.github/config/repo-to-node.yml
+++ b/.github/config/repo-to-node.yml
@@ -8,6 +8,7 @@ HoneyDrunk.Data: honeydrunk-data
 HoneyDrunk.Pulse: pulse
 HoneyDrunk.Notify: honeydrunk-notify
 HoneyDrunk.Communications: honeydrunk-communications
+HoneyDrunk.NovOutbox: honeydrunk-novoutbox
 HoneyDrunk.Actions: honeydrunk-actions
 HoneyDrunk.Architecture: honeydrunk-architecture
 HoneyDrunk.Infrastructure: honeydrunk-infrastructure


### PR DESCRIPTION
## Summary

- map `HoneyDrunk.NovOutbox` to `honeydrunk-novoutbox` in the shared repo-to-node config

## Review pass

Performed an explicit diff review before publishing. No findings remained after review.

## Validation

- `git diff --check origin/main...HEAD`

Authorship: agent-codex
Out-of-band reason: Initial NovOutbox repo-to-node mapping requested directly before a tracked work item exists; Architecture PR #627 records the canonical node registration.
Depends on: HoneyDrunkStudios/HoneyDrunk.Architecture#627
