### PR TITLE
chore(actions): map payments repo

### DIFF
--- a/.github/config/repo-to-node.yml
+++ b/.github/config/repo-to-node.yml
@@ -9,6 +9,7 @@ HoneyDrunk.Pulse: pulse
 HoneyDrunk.Notify: honeydrunk-notify
 HoneyDrunk.Communications: honeydrunk-communications
 HoneyDrunk.NovOutbox: honeydrunk-novoutbox
+HoneyDrunk.Payments: honeydrunk-payments
 HoneyDrunk.Actions: honeydrunk-actions
 HoneyDrunk.Architecture: honeydrunk-architecture
 HoneyDrunk.Infrastructure: honeydrunk-infrastructure


### PR DESCRIPTION
## Summary
- Map `HoneyDrunk.Payments` to `honeydrunk-payments` in the shared Actions repo-to-node config.

## Validation
- `repo-to-node-ok` parser/duplicate check passed.
- `git diff --check` passed.
- Explicit review pass completed; no findings.

Authorship: agent-codex
Work Item: https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/issues/205