### PR TITLE
fix: accept release github token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,6 +229,10 @@ on:
         default: 'main'
     
     secrets:
+      github-token:
+        description: 'GitHub token used for GitHub Release creation'
+        required: false
+
       nuget-api-key:
         description: 'API key for NuGet feed'
         required: false
@@ -852,6 +856,7 @@ jobs:
           generate_release_notes: ${{ steps.notes.outputs.has-changelog == 'false' }}
           draft: ${{ inputs.github-release-draft }}
           prerelease: ${{ inputs.github-release-prerelease }}
+          token: ${{ secrets.github-token || github.token }}
   
   release-summary:
     name: Release Summary

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `release.yml`: expose an optional `github-token` workflow-call secret and pass it to `softprops/action-gh-release` with the built-in `github.token` as a compatibility fallback. Consumers that request centralized GitHub Release creation can now hand off `GITHUB_TOKEN` explicitly, matching the standard HoneyDrunk reusable-workflow token contract.
+
 - `job-review-request.yml`: restored the Grid review request permission contract to `pull-requests: write` plus `issues: write`. The earlier read-only PR scope regressed HoneyHub queueing: the reusable job received `pull-requests: read` and failed with `Resource not accessible by integration` while normalizing labels/comments. Consumer docs now match the known-good Architecture/HoneyHub behavior.
 
 - `job-sonarcloud.yml`: exclude consumer `.github/workflows/**` wrapper YAML from SonarQube Cloud source analysis by default. The wrapper workflows intentionally call first-party reusable workflows from `HoneyDrunk.Actions@main` so repos receive centralized workflow fixes; SonarCloud reports those new wrapper calls as Security Hotspots even though the executable workflow logic is governed in this repo. Consumers can override the new `sonar-exclusions` input when they intentionally want Sonar to scan workflow YAML.

--- a/docs/consumer-usage.md
+++ b/docs/consumer-usage.md
@@ -794,6 +794,8 @@ jobs:
       publish-projects: 'MyWorker/MyWorker.csproj;MyApi/MyApi.csproj'
       publish-runtime: 'linux-x64'
       publish-self-contained: false
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### Container with Custom Build Context
@@ -837,6 +839,8 @@ jobs:
 ### Permissions
 
 `release.yml` callers need `contents: write`, `packages: write`, `id-token: write`, and `security-events: write`. `contents: write` is part of the standard baseline because the reusable release workflow owns GitHub Release creation when `create-github-release: true`; callers that do not create GitHub Releases still use the same baseline so release scaffolds stay uniform. `id-token: write` enables Azure OIDC/SBOM attestation paths, `packages: write` covers package/container publication, and `security-events: write` covers SARIF upload from release-time scans. Missing scopes fail at workflow-load or upload time; broader scopes should be justified by adjacent jobs.
+
+Callers that create GitHub Releases should pass `github-token: ${{ secrets.GITHUB_TOKEN }}` to the reusable workflow. The release workflow falls back to `github.token` for compatibility, but the explicit secret handoff keeps release/package write behavior consistent with other HoneyDrunk reusable workflows.
 
 
 ## Azure Authentication


### PR DESCRIPTION
## Summary
- expose an optional github-token secret on the reusable release workflow
- pass the token to GitHub Release creation with github.token fallback
- document the explicit caller token handoff for release workflows

## Validation
- actionlint .github/workflows/release.yml
- git diff --check

## Review
- Explicit diff review completed; no remaining findings.