### PR TITLE
docs: remove dead README and CHANGELOG links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 
+- Docs: removed two dead documentation links flagged by the 2026-06-19 docs-sync sweep — the `README.md` "Azure DevOps Examples" link pointed at a `devops-example/examples/` directory that was never created, and `docs/CHANGELOG.md` linked to a non-existent `MIGRATION.md`. Breaking changes are documented inline in the changelog's Changed/Removed sections.
 - `actions/azure/deploy-function`: the post-deploy health check now probes the function app's real `defaultHostName` (resolved via `az resource show --resource-type Microsoft.Web/sites`) instead of the assumed `<name>.azurewebsites.net`. Flex Consumption apps answer only on a regional hostname (`<name>-<hash>.<region>-01.azurewebsites.net`), so the bare form returned HTTP 000 and failed the health check even when the deploy itself succeeded. `az functionapp show` is deliberately avoided here — it returns null for `defaultHostName`/`state`/`hostNames` on Flex Consumption apps (a CLI quirk); `az resource show` reads the property straight from ARM and is correct for both Flex and classic plans. Falls back to the constructed form (with a warning) when the lookup is unavailable. Applies to both the production-URL and post-swap-URL resolution.
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -574,7 +574,6 @@ This project is licensed under the terms specified in the [LICENSE](LICENSE) fil
 
 - **[Quick Reference](docs/QUICK-REFERENCE.md)** - Common patterns and troubleshooting
 - **[Examples](examples/)** - Ready-to-use workflow examples
-- **[Azure DevOps Examples](devops-example/examples/)** - Azure Pipelines examples
 - [GitHub Actions Documentation](https://docs.github.com/en/actions)
 - [Azure Pipelines Documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/)
 - [.NET CLI Documentation](https://docs.microsoft.com/en-us/dotnet/core/tools/)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -260,4 +260,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-For migration guides and breaking changes, see [MIGRATION.md](MIGRATION.md) (when applicable).
+Breaking changes are called out under the relevant version's **Changed** and **Removed** sections above.


### PR DESCRIPTION
## Summary
- Fixes two broken documentation links flagged by the 2026-06-19 docs-sync sweep.
- `README.md`: removed the "Azure DevOps Examples" link to `devops-example/examples/`, a directory that was never created in this repo.
- `docs/CHANGELOG.md`: replaced the dead `MIGRATION.md` link with a plain-text note pointing at the inline Changed/Removed sections that already document breaking changes.
- Records the fix under the root `CHANGELOG.md` Unreleased / Fixed section.

Authorship: agent-claude-code

Work Item: N/A
Out-of-band reason: Docs-sync remediation (2026-06-19 Docs Sync Report); mechanical dead-link hygiene with no owning packet/work item.

## Verification
- Confirmed `devops-example/` does not exist and no `MIGRATION.md` exists in the repo.
- Markdown-only change; no workflow/action behavior affected.

Size justification: N/A

